### PR TITLE
Add network performance testing and GPU topology discovery for llm-d inference pods

### DIFF
--- a/run-tests-common.py
+++ b/run-tests-common.py
@@ -1,0 +1,913 @@
+"""Shared utilities and configuration for run-tests*.py modules.
+
+Provides global configuration, kubectl helpers, command execution,
+pod discovery, explain/verify logic, and server process cleanup.
+
+All submodules (run-tests-discovery.py, run-tests-perftest.py,
+run-tests-iperf3.py) import from this module via importlib to
+avoid circular dependencies with the main run-tests.py entry point.
+"""
+
+import atexit
+import io
+import json
+import os
+import re
+import shlex
+import signal
+import subprocess
+import sys
+import threading
+import time
+
+# ---------------------------------------------------------------------------
+# Global configuration — defaults set here, overridden by configure()
+# ---------------------------------------------------------------------------
+VERBOSE = False
+DISCOVER_ONLY = False
+EXPLAIN = False
+EXPLAIN_VERIFY = False
+
+USE_DEBUG_CONTAINER = False
+DEBUG_IMAGE = ""
+DEBUG_SUFFIX = "-debug"
+
+INSTALL_DEPS = False
+OPT_DEVICE = None
+OPT_GID_INDEX = None
+OPT_LABEL = "llm-d.ai/inferenceServing=true"
+OPT_NAMESPACE = None
+
+SSH_COMMAND = None       # e.g. ["ssh", "-i", "/path/key"]
+SSH_HOSTS = []           # [(display_name, ip), ...] — same shape as discover_pods()
+SSH_MODE = False         # derived: True when SSH_HOSTS is non-empty
+_ssh_target_map = {}     # display_name -> ssh_target (e.g. "user@host")
+
+DISPLAY_NAME_MAX_LEN = 32
+
+PERFTEST_DURATION = 5
+PERFTEST_ITERATIONS = 1000
+PERFTEST_PORT = 18515
+
+RDMA_BLOCK_SIZES = [1073741824]  # 1G default
+RDMA_LATENCY_SIZE = 2
+OPT_PERCENTAGE_MARGIN = 10.0
+
+
+def configure(**kwargs):
+    """Set global config values.  Called by main() after CLI parsing."""
+    global SSH_MODE
+    g = globals()
+    for key, val in kwargs.items():
+        if key not in g:
+            raise ValueError(f"Unknown config key: {key}")
+        g[key] = val
+    SSH_MODE = bool(SSH_HOSTS)
+
+
+def _parse_common_args(argv=None, extra_flags=None):
+    """Parse CLI flags shared by all submodule entry points.
+
+    Returns a dict suitable for passing to configure().
+
+    *extra_flags* is an optional dict mapping flag tuples to
+    (config_key, needs_value) pairs so callers can extend parsing
+    without duplicating the loop.  Example::
+
+        extra_flags={
+            ("-r", "--rdma-device"): ("OPT_DEVICE", True),
+            ("-i", "--install-deps"): ("INSTALL_DEPS", False),
+        }
+
+    Boolean (needs_value=False) flags store True when present.
+    Value flags store the next argument or the part after '='.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+
+    if extra_flags is None:
+        extra_flags = {}
+
+    # Built-in shared flags
+    all_flags = {
+        ("-v", "--verbose"):            ("VERBOSE", False),
+        ("-e", "--explain"):            ("EXPLAIN", False),
+        ("-x", "--explain-verify"):     ("EXPLAIN_VERIFY", False),
+        ("-i", "--install-deps"):       ("INSTALL_DEPS", False),
+        ("-l", "--label"):              ("OPT_LABEL", True),
+        ("-n", "--namespace"):          ("OPT_NAMESPACE", True),
+        ("-D", "--debug-image"):        ("DEBUG_IMAGE", True),
+        ("-p", "--percentage-margin"):  ("_PCT_MARGIN_RAW", True),
+        ("--ssh-command", "--ssh-command"):  ("_SSH_COMMAND_RAW", True),
+        ("--ssh-hosts", "--ssh-hosts"):      ("_SSH_HOSTS_RAW", True),
+    }
+    all_flags.update(extra_flags)
+
+    # Build lookup: short/long flag -> (config_key, needs_value, long_form)
+    lookup = {}
+    for flag_tuple, (key, needs_val) in all_flags.items():
+        long_form = flag_tuple[1]  # e.g. "--label"
+        for f in flag_tuple:
+            lookup[f] = (key, needs_val, long_form)
+
+    cfg = {}
+    skip_next = False
+    for i, arg in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
+
+        # Check --flag=value form
+        if "=" in arg:
+            prefix = arg.split("=", 1)[0]
+            if prefix in lookup:
+                key, needs_val, _ = lookup[prefix]
+                if needs_val:
+                    cfg[key] = arg.split("=", 1)[1]
+                continue
+
+        if arg in lookup:
+            key, needs_val, _ = lookup[arg]
+            if needs_val:
+                if i + 1 < len(argv):
+                    cfg[key] = argv[i + 1]
+                    skip_next = True
+            else:
+                cfg[key] = True
+
+    # -x implies -e
+    if cfg.get("EXPLAIN_VERIFY"):
+        cfg["EXPLAIN"] = True
+
+    # Derive USE_DEBUG_CONTAINER from DEBUG_IMAGE
+    if "DEBUG_IMAGE" in cfg:
+        cfg["USE_DEBUG_CONTAINER"] = bool(cfg["DEBUG_IMAGE"])
+        cfg["DEBUG_SUFFIX"] = "-debug"
+
+    # Convert percentage margin to float
+    raw_pct = cfg.pop("_PCT_MARGIN_RAW", None)
+    if raw_pct is not None:
+        cfg["OPT_PERCENTAGE_MARGIN"] = float(raw_pct)
+
+    # Handle SSH flags
+    ssh_hosts_raw = cfg.pop("_SSH_HOSTS_RAW", None)
+    ssh_cmd_raw = cfg.pop("_SSH_COMMAND_RAW", None)
+    if ssh_hosts_raw:
+        cfg["SSH_COMMAND"] = shlex.split(ssh_cmd_raw) if ssh_cmd_raw else ["ssh"]
+        cfg["SSH_HOSTS"], cfg["_ssh_target_map"] = _parse_ssh_hosts(ssh_hosts_raw)
+    elif ssh_cmd_raw:
+        print("Error: --ssh-command requires --ssh-hosts", file=sys.stderr)
+        sys.exit(1)
+
+    return cfg
+
+
+def _parse_ssh_hosts(hosts_str):
+    """Parse comma-separated host list into (display_name, ip) tuples.
+
+    Supported formats per entry:
+      host                    → display_name=host, ip=host, target=host
+      user@host               → display_name=host, ip=host, target=user@host
+      host:ip                 → display_name=host, ip=ip,   target=host
+      user@host:ip            → display_name=host, ip=ip,   target=user@host
+
+    Returns (hosts_list, target_map) where hosts_list matches
+    discover_pods() format [(display_name, ip), ...] and
+    target_map maps display_name -> ssh_target.
+    """
+    hosts = []
+    target_map = {}
+    for entry in hosts_str.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        # Split off explicit IP after ':'
+        if ":" in entry:
+            ssh_part, ip = entry.rsplit(":", 1)
+        else:
+            ssh_part, ip = entry, None
+        # Extract display name (strip user@ prefix)
+        if "@" in ssh_part:
+            display_name = ssh_part.split("@", 1)[1]
+        else:
+            display_name = ssh_part
+        if ip is None:
+            ip = display_name
+        hosts.append((display_name, ip))
+        target_map[display_name] = ssh_part
+    return hosts, target_map
+
+
+def _is_latency_title(title):
+    t = title.lower()
+    return "latency" in t or "jitter" in t or "loss" in t
+
+
+def print_results_summary(pods, all_results, display_names, margin_pct=None):
+    """Print average per metric, flag any result outside margin_pct of the average."""
+    if margin_pct is None:
+        margin_pct = OPT_PERCENTAGE_MARGIN
+    n = len(pods)
+    metrics = list(all_results.keys())
+    if not metrics:
+        return
+
+    print(f"\n{'=' * 60}")
+    print(f"  RESULTS SUMMARY (margin: \u00b1{margin_pct:.0f}%)")
+    print(f"{'=' * 60}")
+
+    any_outlier = False
+    for m in metrics:
+        matrix = all_results[m]
+        is_lat = _is_latency_title(m)
+
+        vals = []
+        entries = []
+        for i in range(n):
+            for j in range(n):
+                if i == j:
+                    continue
+                v = matrix[i][j]
+                if v is not None:
+                    vals.append(v)
+                    entries.append((i, j, v))
+
+        if not vals:
+            print(f"\n  {m}: no results")
+            continue
+
+        avg = sum(vals) / len(vals)
+        min_v = min(vals)
+        max_v = max(vals)
+        fmt = ".4f" if is_lat else ".2f"
+        print(f"\n  {m}:")
+        print(f"    Average: {avg:{fmt}}  Min: {min_v:{fmt}}  Max: {max_v:{fmt}}  "
+              f"({len(vals)} result(s))")
+
+        if avg == 0:
+            continue
+        threshold = margin_pct / 100.0
+        outliers = []
+        for i, j, v in entries:
+            deviation = abs(v - avg) / avg
+            if deviation > threshold:
+                outliers.append((i, j, v, deviation))
+
+        if outliers:
+            any_outlier = True
+            print(f"    OUTLIERS (>{margin_pct:.0f}% from average):")
+            for i, j, v, dev in sorted(outliers, key=lambda x: -x[3]):
+                src = display_names[pods[i][0]]
+                dst = display_names[pods[j][0]]
+                src_role = get_pod_role(pods[i][0])
+                dst_role = get_pod_role(pods[j][0])
+                role_str = ""
+                if src_role or dst_role:
+                    role_str = f" ({src_role or '?'}->{dst_role or '?'})"
+                sign = "+" if v > avg else "-"
+                print(f"      {src} -> {dst}{role_str}: "
+                      f"{v:{fmt}} ({sign}{dev * 100:.1f}% from avg {avg:{fmt}})")
+        else:
+            print(f"    All results within \u00b1{margin_pct:.0f}% of average")
+
+    if not any_outlier:
+        print(f"\n  All metrics within \u00b1{margin_pct:.0f}% margin \u2014 results are consistent.")
+    print()
+
+
+def _discover_and_display(label=None):
+    """Discover pods, detect roles, and print summary.  Returns (pods, display_names)."""
+    lbl = label or OPT_LABEL
+    print(f"Discovering pods with label: {lbl} ...")
+    pods = discover_pods(lbl)
+    display_names = make_display_names([p[0] for p in pods])
+    discover_pod_roles(lbl)
+    print(f"Found {len(pods)} pod(s):")
+    for name, ip in pods:
+        role = get_pod_role(name)
+        role_tag = f"  [{role}]" if role else ""
+        print(f"  {display_names[name]:{DISPLAY_NAME_MAX_LEN}s}  {name}  ({ip}){role_tag}")
+
+    # Show cross-role filtering status
+    test_pairs = _cross_role_pairs(pods)
+    all_pairs_count = len(pods) * (len(pods) - 1)
+    if len(test_pairs) < all_pairs_count:
+        prefill_count = sum(1 for n, _ in pods if get_pod_role(n) == "prefill")
+        decode_count = sum(1 for n, _ in pods if get_pod_role(n) == "decode")
+        print(f"  Cross-role testing: {prefill_count} prefill + {decode_count} decode pods "
+              f"→ {len(test_pairs)} cross-role pairs (skipping {all_pairs_count - len(test_pairs)} same-role pairs)")
+
+    return pods, display_names
+
+
+# ---------------------------------------------------------------------------
+# Global server process cleanup (thread-safe)
+# ---------------------------------------------------------------------------
+_server_procs = []
+_server_procs_lock = threading.Lock()
+
+
+def _server_procs_append(proc):
+    with _server_procs_lock:
+        _server_procs.append(proc)
+
+
+def _server_procs_remove(proc):
+    with _server_procs_lock:
+        if proc in _server_procs:
+            _server_procs.remove(proc)
+
+
+def _cleanup_servers():
+    with _server_procs_lock:
+        procs = list(_server_procs)
+    for proc in procs:
+        try:
+            proc.terminate()
+        except OSError:
+            pass
+    for proc in procs:
+        try:
+            proc.wait(timeout=5)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                proc.kill()
+            except OSError:
+                pass
+    with _server_procs_lock:
+        _server_procs.clear()
+
+
+atexit.register(_cleanup_servers)
+for _sig in (signal.SIGTERM, signal.SIGINT):
+    signal.signal(_sig, lambda s, f: sys.exit(1))
+
+
+# ---------------------------------------------------------------------------
+# Threading utilities (shared by perftest, iperf3, discovery)
+# ---------------------------------------------------------------------------
+class _StreamingBuffer:
+    """Thread-safe buffer that supports incremental flushing to stdout.
+
+    The producer thread calls write().  The consumer (main thread) calls
+    flush_new() to print everything written since the last flush, or
+    flush_all() to print the complete buffer.
+    """
+
+    def __init__(self):
+        self._buf = io.StringIO()
+        self._lock = threading.Lock()
+        self._flushed = 0  # character offset already printed
+
+    def write(self, s):
+        with self._lock:
+            self._buf.write(s)
+
+    def flush_new(self):
+        """Print any new content since last flush. Returns True if anything was printed."""
+        with self._lock:
+            val = self._buf.getvalue()
+        new = val[self._flushed:]
+        if new:
+            print(new, end="", flush=True)
+            self._flushed += len(new)
+            return True
+        return False
+
+    def flush_all(self):
+        """Print entire buffer (anything not yet flushed)."""
+        self.flush_new()
+
+    def getvalue(self):
+        with self._lock:
+            return self._buf.getvalue()
+
+
+def _schedule_parallel_pairs(n, pairs=None):
+    """Schedule directed pairs into waves of non-conflicting pairs.
+
+    If *pairs* is given, only those (i, j) tuples are scheduled.
+    Otherwise all n*(n-1) directed pairs are used.
+
+    Returns a list of waves, where each wave is a list of (i, j) index tuples.
+    Within a wave, no index appears as source or destination more than once,
+    so pairs in the same wave can safely run in parallel.
+    """
+    if pairs is None:
+        remaining = [(i, j) for i in range(n) for j in range(n) if i != j]
+    else:
+        remaining = list(pairs)
+    waves = []
+    while remaining:
+        wave = []
+        used = set()
+        still_remaining = []
+        for pair in remaining:
+            i, j = pair
+            if i not in used and j not in used:
+                wave.append(pair)
+                used.add(i)
+                used.add(j)
+            else:
+                still_remaining.append(pair)
+        waves.append(wave)
+        remaining = still_remaining
+    return waves
+
+
+# ---------------------------------------------------------------------------
+# Size helpers
+# ---------------------------------------------------------------------------
+def _parse_size(s):
+    """Parse a size string like '65536', '64K', '1M', '1G' into bytes (int)."""
+    s = s.strip().upper()
+    multipliers = {"K": 1024, "M": 1024**2, "G": 1024**3}
+    if s and s[-1] in multipliers:
+        return int(float(s[:-1]) * multipliers[s[-1]])
+    return int(s)
+
+
+def _human_size(n):
+    """Return a human-readable size string."""
+    if n >= 1024**3 and n % 1024**3 == 0:
+        return f"{n // 1024**3}G"
+    if n >= 1024**2 and n % 1024**2 == 0:
+        return f"{n // 1024**2}M"
+    if n >= 1024 and n % 1024 == 0:
+        return f"{n // 1024}K"
+    return str(n)
+
+
+# ---------------------------------------------------------------------------
+# ANSI helpers
+# ---------------------------------------------------------------------------
+_ANSI_RE = re.compile(r'\x1b\[[0-9;]*[a-zA-Z]')
+
+
+def _strip_ansi(text):
+    """Remove ANSI escape codes (colors, underline, bold, etc.) from text."""
+    return _ANSI_RE.sub('', text)
+
+
+# ---------------------------------------------------------------------------
+# kubectl helpers
+# ---------------------------------------------------------------------------
+def _kubectl_ns_args():
+    """Return ['-n', namespace] if OPT_NAMESPACE is set, else []."""
+    if OPT_NAMESPACE:
+        return ["-n", OPT_NAMESPACE]
+    return []
+
+
+def _kubectl_exec_prefix(pod_name="<POD>"):
+    """Build the exec prefix string for explain output (kubectl or SSH)."""
+    if SSH_MODE:
+        ssh_cmd_str = " ".join(SSH_COMMAND) if SSH_COMMAND else "ssh"
+        target = _ssh_target_map.get(pod_name, pod_name)
+        return f"{ssh_cmd_str} {target}"
+    ns = f" -n {OPT_NAMESPACE}" if OPT_NAMESPACE else ""
+    return f"kubectl exec{ns} {pod_name} --"
+
+
+# ---------------------------------------------------------------------------
+# Explain / verify logic
+# ---------------------------------------------------------------------------
+def explain(text, indent="    "):
+    """Print an explain block (command + parsing hint) when --explain is active."""
+    if not EXPLAIN:
+        return
+    for line in text.strip().split("\n"):
+        print(f"{indent}# {line}", flush=True)
+
+
+_verify_counts = {"passed": 0, "warned": 0, "failed": 0}
+
+
+def _verify_cmd_inline(cmd, hint, indent):
+    """Execute a command and verify output inline. Called by explain_cmd when -x is active."""
+    hint_lower = (hint or "").lower()
+
+    try:
+        result = subprocess.run(
+            ["bash", "-c", cmd],
+            capture_output=True, text=True, timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        print(f"{indent}  [FAIL: timed out after 30s]", flush=True)
+        if hint:
+            print(f"{indent}  expected: {hint}", flush=True)
+        _verify_counts["failed"] += 1
+        return
+    except Exception as exc:
+        print(f"{indent}  [FAIL: {exc}]", flush=True)
+        if hint:
+            print(f"{indent}  expected: {hint}", flush=True)
+        _verify_counts["failed"] += 1
+        return
+
+    stdout = _strip_ansi(result.stdout.strip())
+
+    # grep returns 1 when no matches; kubectl may add benign stderr
+    stderr_clean = "\n".join(
+        l for l in (result.stderr or "").strip().split("\n")
+        if l.strip() and not l.strip().startswith("Defaulted container")
+        and "command terminated with exit code" not in l
+    ).strip()
+    grep_no_match = (result.returncode == 1
+                     and ("grep" in cmd or "wc" in cmd)
+                     and not stderr_clean)
+    absence_ok = any(w in hint_lower for w in ["absence", "unset", "not set",
+                                                 "if =1", "empty ="])
+
+    # Tool not available: command has 2>/dev/null, exit 1, no output
+    tool_not_found = (result.returncode != 0 and "2>/dev/null" in cmd
+                      and not stdout and not stderr_clean)
+
+    # FAIL: non-zero exit (not a grep no-match, not a missing optional tool)
+    if result.returncode != 0 and not grep_no_match and not tool_not_found:
+        print(f"{indent}  [FAIL: exit code {result.returncode}]", flush=True)
+        if hint:
+            print(f"{indent}  expected: {hint}", flush=True)
+        stderr_out = (result.stderr or "").strip()
+        if stderr_out:
+            for line in stderr_out.split("\n"):
+                print(f"{indent}  stderr: {line}", flush=True)
+        if stdout:
+            for line in stdout.split("\n"):
+                print(f"{indent}  stdout: {line}", flush=True)
+        _verify_counts["failed"] += 1
+        return
+
+    if tool_not_found:
+        print(f"{indent}  [executed — tool not available (install with -i/--install-deps)]", flush=True)
+        _verify_counts["warned"] += 1
+        return
+
+    # Empty output
+    if grep_no_match or not stdout:
+        if absence_ok or grep_no_match:
+            print(f"{indent}  [executed and output verified — no output, absence confirms finding]", flush=True)
+            _verify_counts["passed"] += 1
+        else:
+            print(f"{indent}  [WARN: command succeeded but produced no output]", flush=True)
+            if hint:
+                print(f"{indent}  expected: {hint}", flush=True)
+            _verify_counts["warned"] += 1
+        return
+
+    # Has output — verify hint keywords
+    hint_checks = []
+    stdout_lower = stdout.lower()
+    if hint:
+        if "count" in hint_lower:
+            has_number = any(c.isdigit() for c in stdout)
+            hint_checks.append(("has numeric output", has_number))
+        check_terms = []
+        if "active" in hint_lower:
+            check_terms.append("active")
+        if "nvlink" in hint_lower:
+            check_terms.append(("nv", "nvlink", "nvl"))
+        if "pcie" in hint_lower or "pxb" in hint_lower or "pix" in hint_lower:
+            check_terms.append(("pix", "pxb", "phb", "sys", "pcie"))
+        if "ethernet" in hint_lower or "roce" in hint_lower:
+            check_terms.append(("ethernet", "roce", "infiniband"))
+        if "socket" in hint_lower or "numa" in hint_lower:
+            check_terms.append(("socket", "numa", "node"))
+        if "gpu" in hint_lower:
+            check_terms.append(("gpu", "nvidia"))
+        if "nccl" in hint_lower:
+            check_terms.append(("nccl",))
+        for term in check_terms:
+            if isinstance(term, tuple):
+                found = any(t in stdout_lower for t in term)
+                hint_checks.append((f"contains {'/'.join(term)}", found))
+            else:
+                found = term in stdout_lower
+                hint_checks.append((f"contains '{term}'", found))
+
+    all_checks_ok = all(ok for _, ok in hint_checks) if hint_checks else True
+
+    if all_checks_ok:
+        print(f"{indent}  [executed and output verified]", flush=True)
+        if VERBOSE:
+            for line in stdout.split("\n"):
+                display = line if VERBOSE or len(line) <= 120 else line[:117] + "..."
+                print(f"{indent}  | {display}", flush=True)
+        _verify_counts["passed"] += 1
+    else:
+        check_strs = [f"{'OK' if ok else 'MISS'}: {desc}" for desc, ok in hint_checks]
+        print(f"{indent}  [WARN: {'; '.join(check_strs)}]", flush=True)
+        if hint:
+            print(f"{indent}  expected: {hint}", flush=True)
+        for line in stdout.split("\n"):
+            display = line if len(line) <= 120 else line[:117] + "..."
+            print(f"{indent}  | {display}", flush=True)
+        _verify_counts["warned"] += 1
+
+
+def _print_verify_summary():
+    """Print the verification summary totals."""
+    p = _verify_counts["passed"]
+    w = _verify_counts["warned"]
+    f = _verify_counts["failed"]
+    total = p + w + f
+    if total == 0:
+        return
+    print(f"\n{'─' * 50}")
+    print(f"  Summary of running explanation commands: {p} passed, {w} warned, {f} failed "
+          f"(out of {total} commands)")
+    print(f"{'─' * 50}")
+    if f > 0:
+        print(f"  NOTE: FAIL means the command could not run or returned an error.")
+        print(f"  This may indicate missing tools (install with -i/--install-deps)")
+        print(f"  or permission issues in the pod.")
+    if w > 0:
+        print(f"  NOTE: WARN means the command ran but output was empty or didn't")
+        print(f"  contain expected keywords — results may still be valid.")
+
+
+def explain_cmd(cmd, parse_hint=None, indent="    "):
+    """Print a reproducible command when --explain is active.
+
+    With --explain-verify (-x), also executes the command inline and
+    verifies the output.
+    """
+    if not EXPLAIN:
+        return
+    print(f"{indent}$ {cmd}", flush=True)
+    if parse_hint:
+        print(f"{indent}  # {parse_hint}", flush=True)
+    if EXPLAIN_VERIFY:
+        _verify_cmd_inline(cmd, parse_hint, indent)
+
+
+# ---------------------------------------------------------------------------
+# Command execution
+# ---------------------------------------------------------------------------
+def run_cmd(cmd, capture=True, timeout=120):
+    if VERBOSE:
+        print(f"  $ {' '.join(cmd)}", flush=True)
+    if capture:
+        return subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    else:
+        return subprocess.run(cmd, timeout=timeout)
+
+
+def exec_in_pod(pod_name, cmd_args, timeout=300, use_debug=None):
+    """Execute a command in the pod (or on a remote host via SSH).
+
+    use_debug: None = use global USE_DEBUG_CONTAINER setting,
+               True/False = override for this call.
+    """
+    if SSH_MODE:
+        target = _ssh_target_map.get(pod_name, pod_name)
+        remote_cmd = shlex.join(cmd_args)
+        cmd = list(SSH_COMMAND) + [target, remote_cmd]
+        return run_cmd(cmd, timeout=timeout)
+    debug = USE_DEBUG_CONTAINER if use_debug is None else use_debug
+    ns = _kubectl_ns_args()
+    if debug:
+        container_name = pod_name + DEBUG_SUFFIX
+        cmd = ["kubectl", "exec"] + ns + [pod_name, f"--container={container_name}", "--"] + cmd_args
+    else:
+        cmd = ["kubectl", "exec"] + ns + [pod_name, "--"] + cmd_args
+    return run_cmd(cmd, timeout=timeout)
+
+
+def _build_remote_cmd(pod_name, cmd_args, use_debug=None):
+    """Build the full subprocess command list for remote execution.
+
+    Used by callers that need subprocess.Popen (background servers).
+    """
+    if SSH_MODE:
+        target = _ssh_target_map.get(pod_name, pod_name)
+        return list(SSH_COMMAND) + [target, shlex.join(cmd_args)]
+    debug = USE_DEBUG_CONTAINER if use_debug is None else use_debug
+    ns = _kubectl_ns_args()
+    if debug:
+        container_name = pod_name + DEBUG_SUFFIX
+        return ["kubectl", "exec"] + ns + [pod_name, f"--container={container_name}", "--"] + cmd_args
+    return ["kubectl", "exec"] + ns + [pod_name, "--"] + cmd_args
+
+
+# ---------------------------------------------------------------------------
+# Pod discovery
+# ---------------------------------------------------------------------------
+def discover_pods(label):
+    """Get pod names and IPs for a given label selector (or SSH hosts list)."""
+    if SSH_MODE:
+        if not SSH_HOSTS:
+            print("No SSH hosts configured", file=sys.stderr)
+            sys.exit(1)
+        return list(SSH_HOSTS)
+    cmd = ["kubectl", "get", "pods"] + _kubectl_ns_args() + ["-l", label, "-o", "json"]
+    if VERBOSE:
+        print(f"  $ {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"Error discovering pods with label {label}: {result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    data = json.loads(result.stdout)
+    pods = []
+    for item in data.get("items", []):
+        name = item["metadata"]["name"]
+        ip = item.get("status", {}).get("podIP")
+        if ip:
+            pods.append((name, ip))
+    if not pods:
+        print(f"No pods found with label {label}", file=sys.stderr)
+        sys.exit(1)
+    pods.sort(key=lambda x: x[0])
+    return pods
+
+
+# ---------------------------------------------------------------------------
+# Pod role detection and cross-role pair filtering
+# ---------------------------------------------------------------------------
+_ROLE_LABEL = "llm-d.ai/role"
+
+_pod_roles = {}   # pod_name -> "prefill" | "decode" | None
+
+
+def discover_pod_roles(label):
+    """Fetch the llm-d.ai/role label for all pods matching *label*.
+
+    Populates the global _pod_roles dict.  Returns a dict
+    {pod_name: role_str_or_None}.
+    In SSH mode returns empty dict (no Kubernetes roles).
+    """
+    global _pod_roles
+    if SSH_MODE:
+        return _pod_roles
+    cmd = ["kubectl", "get", "pods"] + _kubectl_ns_args() + [
+        "-l", label, "-o",
+        "jsonpath={range .items[*]}{.metadata.name}={.metadata.labels.llm-d\\.ai/role} {end}",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        return _pod_roles  # best-effort
+    for token in result.stdout.strip().split():
+        if "=" in token:
+            name, role = token.split("=", 1)
+            _pod_roles[name] = role.strip() if role.strip() else None
+    return _pod_roles
+
+
+def get_pod_role(pod_name):
+    """Return the cached role for *pod_name*, or None."""
+    return _pod_roles.get(pod_name)
+
+
+def _cross_role_pairs(pods):
+    """Return list of (i, j) index pairs restricted to cross-role testing.
+
+    If both prefill and decode pods exist, only pairs where one is prefill
+    and the other is decode are returned (in both directions).
+    If all pods share the same role (or roles are unknown), returns all
+    n*(n-1) pairs so no tests are skipped.
+    """
+    n = len(pods)
+    roles = [_pod_roles.get(pods[i][0]) for i in range(n)]
+    role_set = {r for r in roles if r}
+
+    # Need both prefill and decode present to filter
+    if not ({"prefill", "decode"} <= role_set):
+        return [(i, j) for i in range(n) for j in range(n) if i != j]
+
+    pairs = []
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            ri, rj = roles[i], roles[j]
+            if ri and rj and ri != rj:
+                pairs.append((i, j))
+    return pairs
+
+
+def make_display_names(pod_names, max_len=None):
+    """Create short, unique display names from a list of pod names."""
+    if max_len is None:
+        max_len = DISPLAY_NAME_MAX_LEN
+    if not pod_names:
+        return {}
+    if len(pod_names) == 1:
+        n = pod_names[0]
+        return {n: n[:max_len] if len(n) > max_len else n}
+
+    prefix_len = 0
+    for chars in zip(*pod_names):
+        if len(set(chars)) == 1:
+            prefix_len += 1
+        else:
+            break
+
+    reversed_names = [n[::-1] for n in pod_names]
+    suffix_len = 0
+    for chars in zip(*reversed_names):
+        if len(set(chars)) == 1:
+            suffix_len += 1
+        else:
+            break
+
+    tails = []
+    for n in pod_names:
+        end = len(n) - suffix_len if suffix_len > 0 else len(n)
+        tails.append(n[prefix_len:end])
+
+    shared_prefix = pod_names[0][:prefix_len]
+    result = {}
+    for full, tail in zip(pod_names, tails):
+        if not tail:
+            tail = full[-max_len:]
+        if len(tail) >= max_len:
+            tail_keep = max(4, max_len // 2)
+            head_keep = max_len - tail_keep - 3
+            if head_keep < 1:
+                head_keep = 1
+                tail_keep = max_len - 4
+            display = tail[:head_keep] + "..." + tail[-tail_keep:]
+        elif len(tail) < max_len and prefix_len > 0:
+            budget = max_len - len(tail)
+            if budget >= prefix_len + 3:
+                display = shared_prefix[:budget] + tail
+            elif budget >= 4:
+                keep = budget - 3
+                display = shared_prefix[:keep] + "..." + tail
+            else:
+                display = tail
+        else:
+            display = tail
+        result[full] = display
+
+    seen = {}
+    for full in pod_names:
+        d = result[full]
+        if d in seen:
+            seen[d] += 1
+            suffix = str(seen[d])
+            result[full] = d[:max_len - len(suffix)] + suffix
+        else:
+            seen[d] = 1
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Debug containers
+# ---------------------------------------------------------------------------
+def debug_container_running(pod_name, container_name):
+    cmd = [
+        "kubectl", "get", "pod",
+    ] + _kubectl_ns_args() + [
+        pod_name,
+        "-o", f"jsonpath={{.status.ephemeralContainerStatuses[?(@.name==\"{container_name}\")].state.running}}",
+    ]
+    if VERBOSE:
+        print(f"  $ {' '.join(cmd)}", flush=True)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return bool(result.stdout.strip())
+
+
+def create_debug_containers(pods):
+    """Create ephemeral debug containers on all pods if needed."""
+    needed = []
+    for name, _ip in pods:
+        container_name = name + DEBUG_SUFFIX
+        if debug_container_running(name, container_name):
+            print(f"  Debug container '{container_name}' already running in {name}, reusing.", flush=True)
+        else:
+            needed.append((name, container_name))
+
+    for name, container_name in needed:
+        print(f"  Creating debug container '{container_name}' in {name} ...", flush=True)
+        cmd = [
+            "kubectl", "debug",
+        ] + _kubectl_ns_args() + [
+            "-i", name,
+            f"--image={DEBUG_IMAGE}",
+            f"--container={container_name}",
+            "--profile=netadmin",
+            "--", "sleep", "inf",
+        ]
+        if VERBOSE:
+            print(f"  $ {' '.join(cmd)}", flush=True)
+        subprocess.Popen(
+            cmd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    if needed:
+        print("  Waiting for debug containers to be ready ...", flush=True)
+        for _ in range(60):
+            all_ready = all(
+                debug_container_running(name, cname) for name, cname in needed
+            )
+            if all_ready:
+                print("  All debug containers ready.")
+                return
+            time.sleep(1)
+        print("  Warning: timed out waiting for some debug containers.", file=sys.stderr)
+    else:
+        print("  All debug containers already running.")

--- a/run-tests-discovery.py
+++ b/run-tests-discovery.py
@@ -1,0 +1,3051 @@
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""GPU topology discovery for Kubernetes inference pods.
+
+Extracted from run-tests.py — validates GPU topology, NVLink/NVSwitch,
+NUMA affinity, PCIe layout, RDMA NIC status, and environment variables
+(NCCL, UCX, vLLM, CUDA, PyTorch distributed, NIXL) across pods.
+
+Public API:
+    run_topology_validation(pods, display_names) -> dict
+"""
+
+import re
+import sys
+import threading
+from importlib import import_module
+
+# Import shared utilities from the common module.
+# Python module names with hyphens require importlib.
+# Use lazy binding: _common is resolved on first access,
+# avoiding circular import issues during module loading.
+_common = None
+
+
+def _get_common():
+    global _common
+    if _common is None:
+        _common = import_module("run-tests-common")
+    return _common
+
+
+# Delegated to run-tests-common
+def exec_in_pod(*args, **kwargs):
+    return _get_common().exec_in_pod(*args, **kwargs)
+
+
+def explain_cmd(*args, **kwargs):
+    return _get_common().explain_cmd(*args, **kwargs)
+
+
+def _kubectl_ns_args():
+    return _get_common()._kubectl_ns_args()
+
+
+def _kubectl_exec_prefix(pod_name="<POD>"):
+    return _get_common()._kubectl_exec_prefix(pod_name)
+
+
+def _print_verify_summary():
+    return _get_common()._print_verify_summary()
+
+
+def _strip_ansi(text):
+    return _get_common()._strip_ansi(text)
+
+
+# ---------------------------------------------------------------------------
+# GPU Topology Validation
+# ---------------------------------------------------------------------------
+
+# Cache which AMD GPU tool is available per pod ("rocm-smi" or "amd-smi")
+_amd_tool_cache = {}  # pod_name -> str
+
+
+def _get_amd_tool(pod_name):
+    """Return the AMD GPU tool name for a pod (default: 'rocm-smi')."""
+    return _amd_tool_cache.get(pod_name, "rocm-smi")
+
+
+def _detect_gpu_vendor(pod_name):
+    """Detect GPU vendor on a pod: 'nvidia', 'amd', or 'unknown'.
+
+    Tries nvidia-smi first, then rocm-smi, then amd-smi.
+    """
+    result = exec_in_pod(pod_name, ["bash", "-c", "command -v nvidia-smi >/dev/null 2>&1 && echo nvidia; "
+                                     "command -v rocm-smi >/dev/null 2>&1 && echo rocm-smi; "
+                                     "command -v amd-smi >/dev/null 2>&1 && echo amd-smi; true"],
+                         timeout=10, use_debug=False)
+    if result.returncode == 0:
+        out = result.stdout.strip().lower()
+        if "nvidia" in out:
+            return "nvidia"
+        if "rocm-smi" in out:
+            _amd_tool_cache[pod_name] = "rocm-smi"
+            return "amd"
+        if "amd-smi" in out:
+            _amd_tool_cache[pod_name] = "amd-smi"
+            return "amd"
+    return "unknown"
+
+
+def _get_gpu_topo(pod_name, vendor):
+    """Get GPU topology matrix. Returns (output_str, success).
+
+    nvidia: nvidia-smi topo -m
+    amd:    rocm-smi --showtopo / amd-smi topology
+    """
+    if vendor == "nvidia":
+        result = exec_in_pod(pod_name, ["nvidia-smi", "topo", "-m"], timeout=30, use_debug=False)
+    elif vendor == "amd":
+        if _get_amd_tool(pod_name) == "amd-smi":
+            result = exec_in_pod(pod_name, ["amd-smi", "topology"], timeout=30, use_debug=False)
+        else:
+            result = exec_in_pod(pod_name, ["rocm-smi", "--showtopo"], timeout=30, use_debug=False)
+    else:
+        return None, False
+    if result.returncode != 0:
+        return None, False
+    return _strip_ansi(result.stdout.strip()), True
+
+
+def _get_gpu_link_status(pod_name, vendor):
+    """Get GPU interconnect link status. Returns (output_str, success).
+
+    nvidia: nvidia-smi nvlink --status
+    amd:    rocm-smi --showtopoweight / amd-smi topology --weight (xGMI/Infinity Fabric link weights)
+    """
+    if vendor == "nvidia":
+        result = exec_in_pod(pod_name, ["nvidia-smi", "nvlink", "--status"], timeout=30, use_debug=False)
+    elif vendor == "amd":
+        if _get_amd_tool(pod_name) == "amd-smi":
+            result = exec_in_pod(pod_name, ["amd-smi", "topology", "--weight"], timeout=30, use_debug=False)
+        else:
+            result = exec_in_pod(pod_name, ["rocm-smi", "--showtopoweight"], timeout=30, use_debug=False)
+    else:
+        return None, False
+    if result.returncode != 0:
+        return None, False
+    return _strip_ansi(result.stdout.strip()), True
+
+
+def _get_gpu_bus_ids(pod_name, vendor):
+    """Get GPU index and PCI bus ID pairs. Returns list of (index_int, bus_id_str).
+
+    nvidia: nvidia-smi --query-gpu=index,gpu_bus_id --format=csv,noheader
+    amd:    rocm-smi --showbus / amd-smi static --bus (parse GPU ID and bus ID)
+    """
+    pairs = []
+    if vendor == "nvidia":
+        result = exec_in_pod(
+            pod_name,
+            ["bash", "-c", "nvidia-smi --query-gpu=index,gpu_bus_id --format=csv,noheader,nounits 2>/dev/null"],
+            timeout=15, use_debug=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().split("\n"):
+                if "," in line:
+                    idx_s, bus = line.split(",", 1)
+                    idx_s = idx_s.strip()
+                    bus = bus.strip().lower()
+                    # Normalize 8-digit domain to 4-digit
+                    bus = re.sub(r'^0{4,}', '0000', bus)
+                    try:
+                        pairs.append((int(idx_s), bus))
+                    except ValueError:
+                        pass
+    elif vendor == "amd":
+        if _get_amd_tool(pod_name) == "amd-smi":
+            result = exec_in_pod(
+                pod_name,
+                ["bash", "-c", "amd-smi static --bus 2>/dev/null"],
+                timeout=15, use_debug=False,
+            )
+        else:
+            result = exec_in_pod(
+                pod_name,
+                ["bash", "-c", "rocm-smi --showbus 2>/dev/null"],
+                timeout=15, use_debug=False,
+            )
+        if result.returncode == 0 and result.stdout.strip():
+            # rocm-smi --showbus format:  GPU[0] : PCI Bus: 0000:03:00.0
+            # amd-smi static --bus format: GPU: 0  BUS: 0000:03:00.0
+            for line in _strip_ansi(result.stdout).strip().split("\n"):
+                m = re.match(r'.*GPU\[(\d+)\].*:\s*([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.\d)', line)
+                if not m:
+                    m = re.match(r'.*GPU:\s*(\d+).*BUS:\s*([0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[0-9a-fA-F]{2}\.\d)', line, re.IGNORECASE)
+                if m:
+                    pairs.append((int(m.group(1)), m.group(2).lower()))
+    return pairs
+
+
+def _parse_rocm_topo(output):
+    """Parse rocm-smi --showtopo output into connections dict and gpu_labels.
+
+    rocm-smi topology output format varies but typically shows a weight matrix:
+        GPU0  GPU1  GPU2 ...
+    GPU0   0    15    15
+    GPU1  15     0    15
+    ...
+    Or shows link type: XGMI, PCIE, etc.
+
+    Returns (connections, gpu_labels) in the same format as _parse_topo_matrix.
+    """
+    if not output:
+        return {}, []
+    lines = output.strip().split("\n")
+    connections = {}
+    gpu_labels = []
+
+    # Try to find a matrix with GPU labels
+    # Look for lines containing "XGMI" or "PCIE" or weight numbers
+    # Also handle the "Link Type" section of --showtopo
+    in_type_section = False
+    in_weight_section = False
+    header_gpus = []
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        # Detect section headers
+        if "type" in stripped.lower() and "link" in stripped.lower():
+            in_type_section = True
+            in_weight_section = False
+            header_gpus = []
+            continue
+        if "weight" in stripped.lower() or "hop" in stripped.lower():
+            in_type_section = False
+            in_weight_section = True
+            header_gpus = []
+            continue
+
+        # Header row with GPU labels
+        if in_type_section or in_weight_section:
+            parts = stripped.split()
+            if parts and all(p.startswith("GPU") and p[3:].isdigit() for p in parts):
+                header_gpus = parts
+                continue
+            # Data row: GPU0  XGMI  PCIE  XGMI ...
+            if parts and parts[0].startswith("GPU") and parts[0][3:].isdigit() and header_gpus:
+                row_gpu = parts[0]
+                if row_gpu not in gpu_labels:
+                    gpu_labels.append(row_gpu)
+                for col_idx, col_gpu in enumerate(header_gpus):
+                    val_idx = col_idx + 1
+                    if val_idx < len(parts):
+                        val = parts[val_idx].upper()
+                        if in_type_section:
+                            # Map XGMI -> NV-equivalent for consistent analysis
+                            if val == "XGMI":
+                                connections[(row_gpu, col_gpu)] = "XGMI"
+                            elif val == "PCIE":
+                                connections[(row_gpu, col_gpu)] = "SYS"
+                            elif val == "0" or val == "X":
+                                connections[(row_gpu, col_gpu)] = "X"
+                            else:
+                                connections[(row_gpu, col_gpu)] = val
+
+    # If no matrix found, try simpler parsing
+    if not connections:
+        for line in lines:
+            stripped = line.strip()
+            # Look for: GPU[0] -> GPU[1]: XGMI
+            m = re.match(r'GPU\[?(\d+)\]?\s*->\s*GPU\[?(\d+)\]?\s*:\s*(\w+)', stripped)
+            if m:
+                g1 = f"GPU{m.group(1)}"
+                g2 = f"GPU{m.group(2)}"
+                link = m.group(3).upper()
+                connections[(g1, g2)] = link
+                if g1 not in gpu_labels:
+                    gpu_labels.append(g1)
+                if g2 not in gpu_labels:
+                    gpu_labels.append(g2)
+
+    return connections, gpu_labels
+
+
+def _parse_rocm_link_status(output):
+    """Parse rocm-smi --showtopoweight output for xGMI link info.
+
+    Returns (active_count, inactive_count) analogous to NVLink status.
+    """
+    if not output:
+        return 0, 0
+    active = 0
+    inactive = 0
+    for line in output.split("\n"):
+        lower = line.lower()
+        # Count non-zero weights as active xGMI links
+        if "xgmi" in lower:
+            active += 1
+        # Look for weight values — non-zero between GPUs = active link
+        parts = line.strip().split()
+        if parts and parts[0].startswith("GPU"):
+            for val in parts[1:]:
+                try:
+                    w = int(val)
+                    if w > 0 and w < 1000:  # reasonable weight range
+                        active += 1
+                except ValueError:
+                    pass
+    return active, inactive
+
+
+def _run_topo_cmd(pod_name, cmd_args, label):
+    """Run a topology command on a pod and return (stdout, success)."""
+    result = exec_in_pod(pod_name, cmd_args, timeout=30, use_debug=False)
+    if result.returncode != 0:
+        return None, False
+    return _strip_ansi(result.stdout.strip()), True
+
+
+def _parse_nvlink_status(output):
+    """Parse nvidia-smi nvlink --status output.
+
+    Returns (active_count, inactive_count) for NVLink connections.
+    """
+    if not output:
+        return 0, 0
+    active = 0
+    inactive = 0
+    for line in output.split("\n"):
+        lower = line.lower()
+        if "active" in lower and "link" in lower:
+            active += 1
+        elif "inactive" in lower and "link" in lower:
+            inactive += 1
+    return active, inactive
+
+
+def _parse_topo_matrix(output):
+    """Parse nvidia-smi topo -m output.
+
+    Returns a dict mapping (gpu_i, gpu_j) -> connection_type (e.g. NV18, SYS, PIX, PHB, NV#, etc.)
+    and a list of GPU labels.
+    """
+    if not output:
+        return {}, []
+    lines = output.strip().split("\n")
+    # Find the header line (starts with GPU or contains GPU0)
+    header_idx = None
+    for i, line in enumerate(lines):
+        if line.strip().startswith("GPU"):
+            # Check if it looks like a header row with GPU0, GPU1, etc.
+            parts = line.split()
+            if len(parts) > 1 and any(p.startswith("GPU") and p[3:].isdigit() for p in parts[1:]):
+                header_idx = i
+                break
+            # Could also be a data row starting with GPU0, GPU1 etc.
+            if len(parts) > 1 and parts[0].startswith("GPU") and parts[0][3:].isdigit():
+                if header_idx is None:
+                    # Look back for column headers
+                    if i > 0:
+                        prev = lines[i - 1].split()
+                        if any(p.startswith("GPU") for p in prev):
+                            header_idx = i - 1
+                            break
+                    header_idx = i
+                    break
+
+    if header_idx is None:
+        return {}, []
+
+    header_parts = lines[header_idx].split()
+    # Column headers: first column is label, rest are GPU0..GPUN (possibly with CPU/NIC after)
+    gpu_cols = []
+    for p in header_parts:
+        if p.startswith("GPU") and len(p) > 3 and p[3:].isdigit():
+            gpu_cols.append(p)
+
+    connections = {}
+    gpu_labels = []
+    for line in lines[header_idx + 1:]:
+        if not line.strip():
+            continue
+        # Legend section starts after the matrix
+        if line.strip().startswith("Legend:") or line.strip().startswith("X ="):
+            break
+        parts = line.split()
+        if not parts or not (parts[0].startswith("GPU") and len(parts[0]) > 3 and parts[0][3:].isdigit()):
+            continue
+        row_gpu = parts[0]
+        gpu_labels.append(row_gpu)
+        # The connection values follow the GPU label
+        for col_idx, col_gpu in enumerate(gpu_cols):
+            val_idx = col_idx + 1  # offset by 1 for the row label
+            if val_idx < len(parts):
+                connections[(row_gpu, col_gpu)] = parts[val_idx]
+
+    return connections, gpu_labels
+
+
+def _check_nvlink_topology(connections, gpu_labels):
+    """Check if GPUs are connected via NVLink/NVSwitch/xGMI vs PCIe only.
+
+    Recognizes both NVIDIA (NV##, NVL) and AMD (XGMI) high-bandwidth links.
+
+    Returns (has_nvlink, summary_str).
+    """
+    if not connections or not gpu_labels:
+        return False, "no topology data"
+
+    nvlink_pairs = []
+    pcie_only_pairs = []
+    pcie_types = {"PIX", "PHB", "PXB", "SYS", "NODE"}
+
+    for (g1, g2), conn in connections.items():
+        if g1 == g2 or conn == "X":
+            continue
+        if g1 > g2:
+            continue  # avoid counting pairs twice
+        # NVLink (NV#, NVL) or AMD xGMI — high-bandwidth GPU interconnect
+        if conn.startswith("NV") or conn == "NVL" or conn == "XGMI":
+            nvlink_pairs.append((g1, g2, conn))
+        elif conn in pcie_types:
+            pcie_only_pairs.append((g1, g2, conn))
+
+    if nvlink_pairs:
+        return True, f"{len(nvlink_pairs)} GPU pair(s) connected via NVLink/NVSwitch"
+    elif pcie_only_pairs:
+        return False, f"all {len(pcie_only_pairs)} GPU pair(s) connected via PCIe only"
+    else:
+        return False, "could not determine GPU interconnect type"
+
+
+def _check_hop_distance(connections, gpu_labels):
+    """Check for excessive hop distances between GPUs.
+
+    nvidia-smi topo -m connection types ranked from best to worst:
+      NV## / NVL  — NVLink (direct or via NVSwitch), best
+      PIX         — same PCIe switch
+      PXB         — cross PCIe switch but same PCIe root complex
+      PHB         — same NUMA node but different PCIe root complex
+      NODE        — same NUMA node (legacy alias, treated like PHB)
+      SYS         — cross NUMA / cross-socket (QPI/UPI hop)
+
+    Returns list of warning strings for sub-optimal connections.
+    """
+    if not connections or len(gpu_labels) < 2:
+        return []
+
+    # Severity ranking: lower is better.  Anything above the threshold warns.
+    SEVERITY = {"NV": 0, "NVL": 0, "XGMI": 0, "PIX": 1, "PXB": 2, "PHB": 3, "NODE": 3, "SYS": 4}
+    LABEL = {"NV": "NVLink", "NVL": "NVLink", "XGMI": "xGMI/Infinity Fabric",
+             "PIX": "same PCIe switch",
+             "PXB": "cross PCIe switch", "PHB": "cross PCIe root (same NUMA)",
+             "NODE": "same NUMA node", "SYS": "cross-NUMA/cross-socket"}
+    # Warn when severity >= this value (PHB and above)
+    WARN_THRESHOLD = 3
+
+    def _conn_severity(conn):
+        if conn.startswith("NV"):
+            return 0, "NVLink"
+        if conn == "XGMI":
+            return 0, "xGMI/Infinity Fabric"
+        return SEVERITY.get(conn, 5), LABEL.get(conn, conn)
+
+    warns = []
+    seen = set()
+    excessive_hops = {}   # conn_type -> list of (g1, g2)
+    for (g1, g2), conn in connections.items():
+        if g1 == g2 or conn == "X":
+            continue
+        pair = tuple(sorted([g1, g2]))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        sev, desc = _conn_severity(conn)
+        if sev >= WARN_THRESHOLD:
+            excessive_hops.setdefault(conn, []).append(pair)
+
+    for conn_type in sorted(excessive_hops, key=lambda c: _conn_severity(c)[0], reverse=True):
+        pairs = excessive_hops[conn_type]
+        _, desc = _conn_severity(conn_type)
+        pair_strs = [f"{a}<->{b}" for a, b in pairs]
+        if len(pair_strs) <= 4:
+            detail = ", ".join(pair_strs)
+        else:
+            detail = f"{len(pair_strs)} pairs"
+        warns.append(f"{conn_type} ({desc}): {detail}")
+
+    return warns
+
+
+def _check_nvswitch_domains(connections, gpu_labels):
+    """Detect whether GPUs belong to different NVSwitch domains.
+
+    When all GPUs are in the same NVSwitch domain, every GPU pair shows a
+    uniform NV## link count (e.g. NV18 everywhere).  If the NVLink width
+    varies significantly between pairs, GPUs are likely split across
+    separate NVSwitch domains — suboptimal for collective operations.
+
+    Also detects a mixed topology where some GPU pairs use NVLink and
+    others fall back to PCIe, which is a clear domain split.
+
+    Returns (is_uniform, warnings_list).
+    """
+    if not connections or len(gpu_labels) < 2:
+        return True, []
+
+    # Collect NVLink widths and PCIe-fallback pairs
+    nvlink_widths = {}   # (g1,g2) -> int  (the ## in NV##)
+    pcie_pairs = []      # pairs that use PCIe despite NVLink existing elsewhere
+    seen = set()
+
+    has_any_nvlink = False
+    for (g1, g2), conn in connections.items():
+        if g1 == g2 or conn == "X":
+            continue
+        pair = tuple(sorted([g1, g2]))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        if conn.startswith("NV") or conn == "XGMI":
+            has_any_nvlink = True
+            # Extract numeric width: NV18 -> 18, NVL/XGMI -> -1 (present but unnumbered)
+            if conn.startswith("NV"):
+                suffix = conn[2:]
+                width = int(suffix) if suffix.isdigit() else -1
+            else:
+                width = -1  # XGMI — no lane count
+            nvlink_widths[pair] = width
+        else:
+            pcie_pairs.append((pair, conn))
+
+    if not has_any_nvlink:
+        return True, []  # no NVLink at all, nothing to check
+
+    warns = []
+
+    # Check 1: Some pairs use NVLink, others fall back to PCIe
+    if pcie_pairs:
+        fallback_strs = [f"{a}<->{b} ({conn})" for (a, b), conn in pcie_pairs]
+        if len(fallback_strs) <= 4:
+            detail = ", ".join(fallback_strs)
+        else:
+            detail = f"{len(fallback_strs)} pairs"
+        warns.append(
+            f"NVSwitch domain split: {len(nvlink_widths)} pair(s) use NVLink but "
+            f"{len(pcie_pairs)} pair(s) fall back to PCIe: {detail}"
+        )
+
+    # Check 2: Non-uniform NVLink widths (e.g. some NV18, some NV12)
+    numeric_widths = [w for w in nvlink_widths.values() if w > 0]
+    if numeric_widths:
+        unique_widths = set(numeric_widths)
+        if len(unique_widths) > 1:
+            width_counts = {}
+            for w in numeric_widths:
+                width_counts[w] = width_counts.get(w, 0) + 1
+            breakdown = ", ".join(f"NV{w}: {c} pair(s)" for w, c in sorted(width_counts.items()))
+            warns.append(
+                f"Non-uniform NVLink widths across GPU pairs ({breakdown}) — "
+                f"GPUs may span different NVSwitch domains"
+            )
+
+    return len(warns) == 0, warns
+
+
+def _fetch_nccl_env(pod_name):
+    """Fetch NCCL/RDMA/vLLM/CUDA/PyTorch/NIXL environment variables from a pod.
+
+    Returns a dict of var_name -> value for all matching env vars.
+    """
+    # Grep for all inference-relevant env vars in one exec call
+    script = (
+        "env | grep -E "
+        "'^(NCCL_|RDMA_|UCX_|VLLM_|CUDA_|TORCH_|MASTER_|NIXL_|RANK=|WORLD_SIZE=|LOCAL_RANK=)' "
+        "| sort; true"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", script], timeout=15, use_debug=False)
+    env_vars = {}
+    if result.returncode == 0 and result.stdout.strip():
+        for line in result.stdout.strip().split("\n"):
+            if "=" in line:
+                key, _, val = line.partition("=")
+                env_vars[key.strip()] = val.strip()
+    return env_vars
+
+
+def _fetch_rdma_devices(pod_name):
+    """List available RDMA devices, using ibv_devices if available, else sysfs.
+
+    Returns a list of device names (e.g. ['mlx5_0', 'mlx5_1']).
+    """
+    # Try ibv_devices first — provides authoritative list from libibverbs
+    # Filter out header lines (device, ------) keeping only actual device names
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         "ibv_devices 2>/dev/null | awk '/^\\s+/{print $1}' | grep -vE '^(-|device$)'; true"],
+        timeout=15, use_debug=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        devs = sorted(d for d in result.stdout.strip().split()
+                       if not d.startswith("-") and d != "device")
+        if devs:
+            return devs
+
+    # Fallback to sysfs
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", "ls /sys/class/infiniband/ 2>/dev/null; true"],
+        timeout=15, use_debug=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return sorted(result.stdout.strip().split())
+    return []
+
+
+def _fetch_rdma_nic_status(pod_name, rdma_devices):
+    """Fetch detailed RDMA NIC status for each device.
+
+    Uses ibstat if available (richer output including link layer, rate, state),
+    otherwise falls back to sysfs reads.
+
+    Returns a dict: {device_name: {state, phys_state, rate, link_layer, fw_ver, ...}}
+    """
+    if not rdma_devices:
+        return {}
+
+    # Try ibstat first — one call for all devices
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", "command -v ibstat >/dev/null 2>&1 && echo HAS_IBSTAT || echo NO_IBSTAT"],
+        timeout=10, use_debug=False,
+    )
+    has_ibstat = result.returncode == 0 and "HAS_IBSTAT" in result.stdout
+
+    nic_status = {}
+
+    if has_ibstat:
+        # ibstat gives detailed per-device output; query all devices at once
+        result = exec_in_pod(
+            pod_name,
+            ["bash", "-c", f"ibstat {' '.join(rdma_devices)} 2>/dev/null; true"],
+            timeout=30, use_debug=False,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            current_dev = None
+            current_port = None
+            info = {}
+            for line in result.stdout.split("\n"):
+                stripped = line.strip()
+                # Device header: "CA 'mlx5_0'"
+                if stripped.startswith("CA '") or stripped.startswith("CA '"):
+                    if current_dev and info:
+                        nic_status[current_dev] = info
+                    dev_match = stripped.split("'")
+                    current_dev = dev_match[1] if len(dev_match) >= 2 else None
+                    info = {"source": "ibstat"}
+                    current_port = None
+                elif stripped.startswith("Port ") and current_dev:
+                    current_port = stripped.rstrip(":")
+                elif ":" in stripped and current_dev:
+                    key, _, val = stripped.partition(":")
+                    key = key.strip().lower()
+                    val = val.strip()
+                    if key == "state":
+                        info["state"] = val
+                    elif key == "physical state":
+                        info["phys_state"] = val
+                    elif key == "rate":
+                        info["rate"] = val
+                    elif key == "base lid":
+                        info["lid"] = val
+                    elif key == "sm lid":
+                        info["sm_lid"] = val
+                    elif key == "link layer":
+                        info["link_layer"] = val
+                    elif key == "fw ver":
+                        info["fw_ver"] = val
+                    elif key == "node guid":
+                        info["node_guid"] = val
+                    elif key == "ca type":
+                        info["ca_type"] = val
+                    elif key == "number of ports":
+                        info["num_ports"] = val
+            if current_dev and info:
+                nic_status[current_dev] = info
+
+    # Fallback or fill gaps using sysfs — batched in a single exec
+    missing = [d for d in rdma_devices if d not in nic_status]
+    if missing or not has_ibstat:
+        devices_to_query = missing if has_ibstat else rdma_devices
+        if devices_to_query:
+            # Build a batched sysfs read script
+            reads = []
+            for dev in devices_to_query:
+                reads.append(
+                    f'echo "DEV:{dev}";'
+                    f'cat /sys/class/infiniband/{dev}/ports/1/state 2>/dev/null || echo "?";'
+                    f'cat /sys/class/infiniband/{dev}/ports/1/phys_state 2>/dev/null || echo "?";'
+                    f'cat /sys/class/infiniband/{dev}/ports/1/rate 2>/dev/null || echo "?";'
+                    f'cat /sys/class/infiniband/{dev}/ports/1/link_layer 2>/dev/null || echo "?";'
+                    f'cat /sys/class/infiniband/{dev}/fw_ver 2>/dev/null || echo "?";'
+                )
+            script = " ".join(reads) + " true"
+            result = exec_in_pod(
+                pod_name, ["bash", "-c", script], timeout=30, use_debug=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                lines = result.stdout.strip().split("\n")
+                i = 0
+                while i < len(lines):
+                    line = lines[i].strip()
+                    if line.startswith("DEV:"):
+                        dev = line[4:]
+                        info = nic_status.get(dev, {"source": "sysfs"})
+                        # Read next 5 values: state, phys_state, rate, link_layer, fw_ver
+                        if i + 1 < len(lines):
+                            raw_state = lines[i + 1].strip()
+                            # sysfs state format: "4: ACTIVE" or just "ACTIVE"
+                            info.setdefault("state", raw_state.split(":", 1)[-1].strip() if ":" in raw_state else raw_state)
+                        if i + 2 < len(lines):
+                            raw_phys = lines[i + 2].strip()
+                            info.setdefault("phys_state", raw_phys.split(":", 1)[-1].strip() if ":" in raw_phys else raw_phys)
+                        if i + 3 < len(lines):
+                            info.setdefault("rate", lines[i + 3].strip())
+                        if i + 4 < len(lines):
+                            info.setdefault("link_layer", lines[i + 4].strip())
+                        if i + 5 < len(lines):
+                            info.setdefault("fw_ver", lines[i + 5].strip())
+                        nic_status[dev] = info
+                        i += 6
+                    else:
+                        i += 1
+
+    return nic_status
+
+
+def _fetch_net_interfaces(pod_name):
+    """List network interfaces from the pod.
+
+    Returns a list of interface names.
+    """
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", "ls /sys/class/net/ 2>/dev/null; true"],
+        timeout=15, use_debug=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return sorted(result.stdout.strip().split())
+    return []
+
+
+def _validate_nccl_env(env_vars, rdma_devices, net_interfaces):
+    """Validate NCCL environment variables against actual pod hardware.
+
+    Returns (findings, warnings) where findings is a list of info strings
+    and warnings is a list of warning strings.
+    """
+    findings = []
+    warns = []
+
+    # --- NCCL_IB_DISABLE ---
+    ib_disable = env_vars.get("NCCL_IB_DISABLE")
+    if ib_disable is not None:
+        if ib_disable == "1":
+            findings.append("NCCL_IB_DISABLE=1 — InfiniBand/RoCE disabled")
+            if rdma_devices:
+                warns.append(
+                    f"NCCL_IB_DISABLE=1 but RDMA devices present: "
+                    f"{', '.join(rdma_devices)} — IB/RoCE will not be used"
+                )
+        else:
+            findings.append(f"NCCL_IB_DISABLE={ib_disable} — InfiniBand/RoCE enabled")
+    else:
+        findings.append("NCCL_IB_DISABLE not set (IB/RoCE enabled by default)")
+
+    # --- NCCL_IB_HCA ---
+    ib_hca = env_vars.get("NCCL_IB_HCA")
+    if ib_hca is not None:
+        findings.append(f"NCCL_IB_HCA={ib_hca}")
+        # Parse HCA list: entries can be =exact, ^exclude, prefix, or device:port
+        hca_entries = [e.strip() for e in ib_hca.split(",") if e.strip()]
+        for entry in hca_entries:
+            # Strip leading = or ^ and trailing :port
+            clean = entry.lstrip("=^")
+            if ":" in clean:
+                clean = clean.split(":")[0]
+            # Check if this device exists (prefix match for entries without =)
+            if entry.startswith("^"):
+                # Exclusion — just note it
+                continue
+            if entry.startswith("="):
+                # Exact match
+                if clean not in rdma_devices:
+                    warns.append(
+                        f"NCCL_IB_HCA specifies ={clean} but device not found "
+                        f"(available: {', '.join(rdma_devices) or 'none'})"
+                    )
+            else:
+                # Prefix match
+                matched = [d for d in rdma_devices if d.startswith(clean)]
+                if not matched:
+                    warns.append(
+                        f"NCCL_IB_HCA specifies '{entry}' but no RDMA device "
+                        f"matches prefix '{clean}' "
+                        f"(available: {', '.join(rdma_devices) or 'none'})"
+                    )
+    else:
+        if rdma_devices:
+            findings.append(
+                f"NCCL_IB_HCA not set — NCCL will use all RDMA devices: "
+                f"{', '.join(rdma_devices)}"
+            )
+        else:
+            findings.append("NCCL_IB_HCA not set (no RDMA devices found)")
+
+    # --- NCCL_EXCLUDE_IB_HCA ---
+    exclude_hca = env_vars.get("NCCL_EXCLUDE_IB_HCA")
+    if exclude_hca is not None:
+        findings.append(f"NCCL_EXCLUDE_IB_HCA={exclude_hca}")
+        if ib_hca is not None:
+            warns.append(
+                "Both NCCL_IB_HCA and NCCL_EXCLUDE_IB_HCA are set — "
+                "NCCL_IB_HCA takes precedence, NCCL_EXCLUDE_IB_HCA is ignored"
+            )
+
+    # --- NCCL_SOCKET_IFNAME ---
+    socket_ifname = env_vars.get("NCCL_SOCKET_IFNAME")
+    if socket_ifname is not None:
+        findings.append(f"NCCL_SOCKET_IFNAME={socket_ifname}")
+        # Can be a prefix or comma-separated list of prefixes; ^ means exclude
+        ifname_entries = [e.strip() for e in socket_ifname.split(",") if e.strip()]
+        for entry in ifname_entries:
+            if entry.startswith("^"):
+                continue  # exclusion
+            # Check prefix match against interfaces
+            matched = [i for i in net_interfaces if i.startswith(entry)]
+            if not matched:
+                warns.append(
+                    f"NCCL_SOCKET_IFNAME specifies '{entry}' but no network "
+                    f"interface matches (available: {', '.join(net_interfaces) or 'none'})"
+                )
+    else:
+        findings.append("NCCL_SOCKET_IFNAME not set (NCCL will auto-select)")
+
+    # --- NCCL_NET ---
+    nccl_net = env_vars.get("NCCL_NET")
+    if nccl_net is not None:
+        findings.append(f"NCCL_NET={nccl_net}")
+
+    # --- NCCL_IB_GID_INDEX ---
+    gid_index = env_vars.get("NCCL_IB_GID_INDEX")
+    if gid_index is not None:
+        findings.append(f"NCCL_IB_GID_INDEX={gid_index}")
+
+    # --- NCCL_IB_TIMEOUT ---
+    ib_timeout = env_vars.get("NCCL_IB_TIMEOUT")
+    if ib_timeout is not None:
+        findings.append(f"NCCL_IB_TIMEOUT={ib_timeout}")
+
+    # --- NCCL_IB_TC ---
+    ib_tc = env_vars.get("NCCL_IB_TC")
+    if ib_tc is not None:
+        findings.append(f"NCCL_IB_TC={ib_tc}")
+
+    # --- NCCL_NET_GDR_LEVEL ---
+    gdr = env_vars.get("NCCL_NET_GDR_LEVEL")
+    if gdr is not None:
+        findings.append(f"NCCL_NET_GDR_LEVEL={gdr}")
+
+    # --- NCCL_VERSION ---
+    nccl_ver = env_vars.get("NCCL_VERSION")
+    if nccl_ver is not None:
+        findings.append(f"NCCL_VERSION={nccl_ver}")
+
+    # =====================================================================
+    # UCX environment variables — used by frameworks like PyTorch, DeepSpeed,
+    # and Horovod when UCX is the transport layer (instead of or alongside NCCL).
+    # UCX controls which transports, devices, and protocols are used for
+    # GPU-GPU and node-to-node communication.
+    # =====================================================================
+    ucx_vars = {k: v for k, v in env_vars.items() if k.startswith("UCX_")}
+    if ucx_vars:
+        findings.append(f"UCX: {len(ucx_vars)} variable(s) set")
+
+    # --- UCX_TLS (transport layers) ---
+    ucx_tls = env_vars.get("UCX_TLS")
+    if ucx_tls is not None:
+        findings.append(f"UCX_TLS={ucx_tls}")
+        tls_list = [t.strip().lower() for t in ucx_tls.split(",")]
+        # Topology impact analysis
+        if "rc" in tls_list or "rc_v" in tls_list or "rc_x" in tls_list:
+            findings.append("  -> rc/rc_v/rc_x: Reliable Connected IB verbs (RDMA, low latency)")
+        if "ud" in tls_list or "ud_v" in tls_list or "ud_x" in tls_list:
+            findings.append("  -> ud/ud_v/ud_x: Unreliable Datagram IB verbs (RDMA, connectionless)")
+        if "dc" in tls_list or "dc_x" in tls_list:
+            findings.append("  -> dc/dc_x: Dynamic Connected IB (scalable RDMA, fewer QPs)")
+        if "tcp" in tls_list:
+            findings.append("  -> tcp: TCP sockets (fallback, no RDMA — high latency)")
+            if rdma_devices:
+                warns.append(
+                    "UCX_TLS includes 'tcp' but RDMA devices are present — "
+                    "TCP is a slow fallback; consider rc_v or dc_x for RDMA transport"
+                )
+        if "cuda_copy" in tls_list:
+            findings.append("  -> cuda_copy: GPU memory staging via cudaMemcpy")
+        if "cuda_ipc" in tls_list:
+            findings.append("  -> cuda_ipc: GPU-GPU direct transfer via CUDA IPC (same node)")
+        if "gdr_copy" in tls_list:
+            findings.append("  -> gdr_copy: GPUDirect RDMA copy (GPU memory <-> host via BAR)")
+        if "sm" in tls_list or "shm" in tls_list:
+            findings.append("  -> sm/shm: shared memory (intra-node only)")
+        if "self" in tls_list:
+            findings.append("  -> self: loopback (same process)")
+        # Check for missing RDMA transports when RDMA devices exist
+        rdma_tls = {"rc", "rc_v", "rc_x", "ud", "ud_v", "ud_x", "dc", "dc_x"}
+        if rdma_devices and not (set(tls_list) & rdma_tls):
+            warns.append(
+                f"UCX_TLS={ucx_tls} has no RDMA transport (rc/ud/dc) but "
+                f"RDMA devices are present — inter-node traffic will not use RDMA"
+            )
+    else:
+        if ucx_vars:
+            findings.append("UCX_TLS not set (UCX auto-selects transports)")
+
+    # --- UCX_NET_DEVICES (RDMA device selection) ---
+    ucx_net_devs = env_vars.get("UCX_NET_DEVICES")
+    if ucx_net_devs is not None:
+        findings.append(f"UCX_NET_DEVICES={ucx_net_devs}")
+        # Validate devices exist
+        dev_entries = [d.strip() for d in ucx_net_devs.split(",") if d.strip()]
+        for entry in dev_entries:
+            # UCX device format: mlx5_0:1 (device:port) or just mlx5_0
+            dev_name = entry.split(":")[0]
+            if dev_name not in rdma_devices and dev_name != "all":
+                warns.append(
+                    f"UCX_NET_DEVICES specifies '{entry}' but device '{dev_name}' "
+                    f"not found (available: {', '.join(rdma_devices) or 'none'})"
+                )
+
+    # --- UCX_IB_PCI_BW (expected IB PCI bandwidth) ---
+    ucx_ib_pci_bw = env_vars.get("UCX_IB_PCI_BW")
+    if ucx_ib_pci_bw is not None:
+        findings.append(f"UCX_IB_PCI_BW={ucx_ib_pci_bw} (PCI bandwidth hint for UCX transport selection)")
+
+    # --- UCX_RNDV_THRESH (rendezvous threshold) ---
+    ucx_rndv = env_vars.get("UCX_RNDV_THRESH")
+    if ucx_rndv is not None:
+        findings.append(f"UCX_RNDV_THRESH={ucx_rndv} (messages above this use rendezvous/zero-copy)")
+
+    # --- UCX_MAX_RNDV_RAILS (multi-rail) ---
+    ucx_rails = env_vars.get("UCX_MAX_RNDV_RAILS")
+    if ucx_rails is not None:
+        findings.append(f"UCX_MAX_RNDV_RAILS={ucx_rails} (max RDMA devices used in parallel for large messages)")
+
+    # --- UCX_MEMTYPE_CACHE ---
+    ucx_memcache = env_vars.get("UCX_MEMTYPE_CACHE")
+    if ucx_memcache is not None:
+        findings.append(f"UCX_MEMTYPE_CACHE={ucx_memcache}")
+        if ucx_memcache.lower() in ("n", "no", "0", "false"):
+            findings.append("  -> memory type cache disabled — may reduce GPU memory registration performance")
+
+    # --- UCX_ZCOPY_THRESH (zero-copy threshold) ---
+    ucx_zcopy = env_vars.get("UCX_ZCOPY_THRESH")
+    if ucx_zcopy is not None:
+        findings.append(f"UCX_ZCOPY_THRESH={ucx_zcopy} (threshold for zero-copy RDMA sends)")
+
+    # --- UCX_IB_GID_INDEX ---
+    ucx_gid = env_vars.get("UCX_IB_GID_INDEX")
+    if ucx_gid is not None:
+        findings.append(f"UCX_IB_GID_INDEX={ucx_gid} (RoCE GID index for UCX)")
+
+    # --- UCX_IB_TRAFFIC_CLASS ---
+    ucx_tc = env_vars.get("UCX_IB_TRAFFIC_CLASS")
+    if ucx_tc is not None:
+        findings.append(f"UCX_IB_TRAFFIC_CLASS={ucx_tc} (QoS traffic class for IB)")
+
+    # --- UCX_IB_SL (Service Level) ---
+    ucx_sl = env_vars.get("UCX_IB_SL")
+    if ucx_sl is not None:
+        findings.append(f"UCX_IB_SL={ucx_sl} (IB Service Level for QoS routing)")
+
+    # --- Topology-relevant UCX interactions ---
+    # Check NCCL_NET + UCX interaction
+    if nccl_net is not None and nccl_net.lower() == "ucx":
+        findings.append("NCCL_NET=UCX — NCCL uses UCX as its network transport plugin")
+        if not ucx_tls:
+            findings.append("  -> UCX_TLS not set — UCX will auto-select transports")
+        if not ucx_net_devs:
+            findings.append("  -> UCX_NET_DEVICES not set — UCX will auto-select RDMA devices")
+
+    # Dump any remaining UCX vars not specifically handled above
+    _handled_ucx = {"UCX_TLS", "UCX_NET_DEVICES", "UCX_IB_PCI_BW", "UCX_RNDV_THRESH",
+                    "UCX_MAX_RNDV_RAILS", "UCX_MEMTYPE_CACHE", "UCX_ZCOPY_THRESH",
+                    "UCX_IB_GID_INDEX", "UCX_IB_TRAFFIC_CLASS", "UCX_IB_SL"}
+    other_ucx = {k: v for k, v in ucx_vars.items() if k not in _handled_ucx}
+    if other_ucx:
+        for k, v in sorted(other_ucx.items()):
+            findings.append(f"{k}={v}")
+
+    return findings, warns
+
+
+def _validate_vllm_cuda_env(env_vars, gpu_count, rdma_devices, has_nvlink):
+    """Validate vLLM, CUDA, PyTorch distributed, and NIXL env vars for inference.
+
+    Returns (findings, warnings) where findings is a list of info strings
+    and warnings is a list of warning strings.
+    """
+    findings = []
+    warns = []
+
+    # =====================================================================
+    # CUDA environment variables
+    # =====================================================================
+    cuda_vars = {k: v for k, v in env_vars.items() if k.startswith("CUDA_")}
+    if cuda_vars:
+        findings.append(f"CUDA: {len(cuda_vars)} variable(s) set")
+
+    # --- CUDA_VISIBLE_DEVICES ---
+    cuda_visible = env_vars.get("CUDA_VISIBLE_DEVICES")
+    if cuda_visible is not None:
+        findings.append(f"CUDA_VISIBLE_DEVICES={cuda_visible}")
+        try:
+            visible_count = len([d.strip() for d in cuda_visible.split(",") if d.strip()])
+            if gpu_count and visible_count != gpu_count:
+                warns.append(
+                    f"CUDA_VISIBLE_DEVICES lists {visible_count} device(s) but "
+                    f"GPU topology shows {gpu_count} — potential mismatch"
+                )
+        except Exception:
+            pass
+
+    # --- CUDA_DEVICE_ORDER ---
+    cuda_dev_order = env_vars.get("CUDA_DEVICE_ORDER")
+    if cuda_dev_order is not None:
+        findings.append(f"CUDA_DEVICE_ORDER={cuda_dev_order}")
+        if cuda_dev_order != "PCI_BUS_ID":
+            warns.append(
+                f"CUDA_DEVICE_ORDER={cuda_dev_order} — recommend PCI_BUS_ID "
+                f"for deterministic GPU ordering that matches nvidia-smi"
+            )
+    else:
+        if gpu_count and gpu_count > 1:
+            findings.append(
+                "CUDA_DEVICE_ORDER not set — defaults to FASTEST_FIRST, "
+                "recommend PCI_BUS_ID for stable ordering"
+            )
+
+    # --- CUDA_MODULE_LOADING ---
+    cuda_module = env_vars.get("CUDA_MODULE_LOADING")
+    if cuda_module is not None:
+        findings.append(f"CUDA_MODULE_LOADING={cuda_module}")
+        if cuda_module.upper() == "EAGER":
+            findings.append(
+                "  -> EAGER: all CUDA modules loaded at startup — "
+                "LAZY reduces memory and startup time for inference"
+            )
+    else:
+        findings.append("CUDA_MODULE_LOADING not set (defaults to EAGER)")
+
+    # --- CUDA_LAUNCH_BLOCKING ---
+    cuda_blocking = env_vars.get("CUDA_LAUNCH_BLOCKING")
+    if cuda_blocking == "1":
+        warns.append(
+            "CUDA_LAUNCH_BLOCKING=1 — all CUDA operations run synchronously, "
+            "severe performance penalty; should only be set for debugging"
+        )
+
+    # =====================================================================
+    # vLLM environment variables
+    # =====================================================================
+    vllm_vars = {k: v for k, v in env_vars.items() if k.startswith("VLLM_")}
+    if vllm_vars:
+        findings.append(f"vLLM: {len(vllm_vars)} variable(s) set")
+
+    # --- VLLM_HOST_IP ---
+    vllm_host_ip = env_vars.get("VLLM_HOST_IP")
+    if vllm_host_ip is not None:
+        findings.append(f"VLLM_HOST_IP={vllm_host_ip}")
+
+    # --- VLLM_PORT ---
+    vllm_port = env_vars.get("VLLM_PORT")
+    if vllm_port is not None:
+        findings.append(f"VLLM_PORT={vllm_port}")
+
+    # --- VLLM_WORKER_MULTIPROC_METHOD ---
+    multiproc = env_vars.get("VLLM_WORKER_MULTIPROC_METHOD")
+    if multiproc is not None:
+        findings.append(f"VLLM_WORKER_MULTIPROC_METHOD={multiproc}")
+
+    # --- VLLM_DISABLE_PYNCCL ---
+    disable_pynccl = env_vars.get("VLLM_DISABLE_PYNCCL")
+    if disable_pynccl == "1":
+        warns.append(
+            "VLLM_DISABLE_PYNCCL=1 — PyNCCL disabled, falling back to "
+            "torch.distributed which may be slower for tensor parallel"
+        )
+
+    # --- VLLM_NCCL_SO_PATH ---
+    nccl_so = env_vars.get("VLLM_NCCL_SO_PATH")
+    if nccl_so is not None:
+        findings.append(f"VLLM_NCCL_SO_PATH={nccl_so}")
+
+    # --- VLLM_CPU_KVCACHE_SPACE ---
+    kv_space = env_vars.get("VLLM_CPU_KVCACHE_SPACE")
+    if kv_space is not None:
+        findings.append(f"VLLM_CPU_KVCACHE_SPACE={kv_space} GiB (CPU memory for KV cache offload)")
+
+    # --- VLLM_ENGINE_ITERATION_TIMEOUT_S ---
+    engine_timeout = env_vars.get("VLLM_ENGINE_ITERATION_TIMEOUT_S")
+    if engine_timeout is not None:
+        findings.append(f"VLLM_ENGINE_ITERATION_TIMEOUT_S={engine_timeout}")
+        try:
+            if int(engine_timeout) < 30:
+                warns.append(
+                    f"VLLM_ENGINE_ITERATION_TIMEOUT_S={engine_timeout} — "
+                    f"low timeout may cause spurious failures under load"
+                )
+        except ValueError:
+            pass
+
+    # --- VLLM_RPC_TIMEOUT ---
+    rpc_timeout = env_vars.get("VLLM_RPC_TIMEOUT")
+    if rpc_timeout is not None:
+        findings.append(f"VLLM_RPC_TIMEOUT={rpc_timeout}")
+
+    # --- VLLM_USE_NCCL_SYMM_MEM ---
+    symm_mem = env_vars.get("VLLM_USE_NCCL_SYMM_MEM")
+    if symm_mem is not None:
+        findings.append(f"VLLM_USE_NCCL_SYMM_MEM={symm_mem}")
+
+    # --- vLLM data parallelism ---
+    vllm_dp_size = env_vars.get("VLLM_DP_SIZE")
+    if vllm_dp_size is not None:
+        findings.append(f"VLLM_DP_SIZE={vllm_dp_size}")
+    vllm_dp_rank = env_vars.get("VLLM_DP_RANK")
+    if vllm_dp_rank is not None:
+        findings.append(f"VLLM_DP_RANK={vllm_dp_rank}")
+    vllm_dp_master = env_vars.get("VLLM_DP_MASTER_IP")
+    if vllm_dp_master is not None:
+        findings.append(f"VLLM_DP_MASTER_IP={vllm_dp_master}")
+        if vllm_dp_master in ("127.0.0.1", "localhost") and vllm_dp_size and vllm_dp_size != "1":
+            warns.append(
+                f"VLLM_DP_MASTER_IP={vllm_dp_master} but VLLM_DP_SIZE={vllm_dp_size} — "
+                f"multi-node data parallel requires a routable IP, not localhost"
+            )
+
+    # --- VLLM_FLOAT32_MATMUL_PRECISION ---
+    matmul_prec = env_vars.get("VLLM_FLOAT32_MATMUL_PRECISION")
+    if matmul_prec is not None:
+        findings.append(f"VLLM_FLOAT32_MATMUL_PRECISION={matmul_prec}")
+        if matmul_prec == "highest":
+            findings.append(
+                "  -> 'highest' uses FP32; 'medium' uses TF32 which is "
+                "faster and sufficient for inference"
+            )
+
+    # --- VLLM_TARGET_DEVICE ---
+    target_dev = env_vars.get("VLLM_TARGET_DEVICE")
+    if target_dev is not None:
+        findings.append(f"VLLM_TARGET_DEVICE={target_dev}")
+
+    # --- vLLM ROCm-specific ---
+    rocm_aiter = env_vars.get("VLLM_ROCM_USE_AITER")
+    if rocm_aiter is not None:
+        findings.append(f"VLLM_ROCM_USE_AITER={rocm_aiter}")
+    rocm_quick = env_vars.get("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION")
+    if rocm_quick is not None:
+        findings.append(f"VLLM_ROCM_QUICK_REDUCE_QUANTIZATION={rocm_quick}")
+
+    # Dump remaining vLLM vars not specifically handled above
+    _handled_vllm = {
+        "VLLM_HOST_IP", "VLLM_PORT", "VLLM_WORKER_MULTIPROC_METHOD",
+        "VLLM_DISABLE_PYNCCL", "VLLM_NCCL_SO_PATH", "VLLM_CPU_KVCACHE_SPACE",
+        "VLLM_ENGINE_ITERATION_TIMEOUT_S", "VLLM_RPC_TIMEOUT",
+        "VLLM_USE_NCCL_SYMM_MEM", "VLLM_DP_SIZE", "VLLM_DP_RANK",
+        "VLLM_DP_MASTER_IP", "VLLM_DP_MASTER_PORT",
+        "VLLM_FLOAT32_MATMUL_PRECISION", "VLLM_TARGET_DEVICE",
+        "VLLM_ROCM_USE_AITER", "VLLM_ROCM_USE_AITER_PAGED_ATTN",
+        "VLLM_ROCM_USE_AITER_MOE", "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION",
+    }
+    other_vllm = {k: v for k, v in vllm_vars.items() if k not in _handled_vllm}
+    if other_vllm:
+        for k, v in sorted(other_vllm.items()):
+            findings.append(f"{k}={v}")
+
+    # =====================================================================
+    # NCCL performance-tuning variables (beyond basic validation)
+    # =====================================================================
+
+    # --- NCCL_P2P_DISABLE ---
+    p2p_disable = env_vars.get("NCCL_P2P_DISABLE")
+    if p2p_disable == "1":
+        if gpu_count and gpu_count > 1:
+            warns.append(
+                "NCCL_P2P_DISABLE=1 — GPU-to-GPU direct transfer disabled; "
+                "severe performance hit for tensor parallel inference with multiple GPUs"
+            )
+        else:
+            findings.append("NCCL_P2P_DISABLE=1 (no impact with single GPU)")
+
+    # --- NCCL_SHM_DISABLE ---
+    shm_disable = env_vars.get("NCCL_SHM_DISABLE")
+    if shm_disable == "1":
+        if gpu_count and gpu_count > 1:
+            warns.append(
+                "NCCL_SHM_DISABLE=1 — shared memory transport disabled; "
+                "reduces intra-node communication performance"
+            )
+
+    # --- NCCL_ALGO / NCCL_PROTO ---
+    nccl_algo = env_vars.get("NCCL_ALGO")
+    if nccl_algo is not None:
+        findings.append(f"NCCL_ALGO={nccl_algo} (forced collective algorithm)")
+    nccl_proto = env_vars.get("NCCL_PROTO")
+    if nccl_proto is not None:
+        findings.append(f"NCCL_PROTO={nccl_proto} (forced protocol)")
+
+    # --- NCCL_MAX_CTAS / NCCL_NTHREADS ---
+    max_ctas = env_vars.get("NCCL_MAX_CTAS")
+    if max_ctas is not None:
+        findings.append(
+            f"NCCL_MAX_CTAS={max_ctas} (limits NCCL GPU thread blocks — "
+            f"lower values reduce GPU contention for inference)"
+        )
+    nccl_nthreads = env_vars.get("NCCL_NTHREADS")
+    if nccl_nthreads is not None:
+        findings.append(f"NCCL_NTHREADS={nccl_nthreads} (CUDA threads per NCCL kernel block)")
+
+    # --- NCCL_NVLS_ENABLE ---
+    nvls_enable = env_vars.get("NCCL_NVLS_ENABLE")
+    if nvls_enable is not None:
+        findings.append(f"NCCL_NVLS_ENABLE={nvls_enable}")
+        if nvls_enable == "0" and has_nvlink:
+            warns.append(
+                "NCCL_NVLS_ENABLE=0 but NVLink/NVSwitch present — "
+                "NVLink SHARP is disabled, may reduce allreduce performance"
+            )
+
+    # --- NCCL_CROSS_NIC ---
+    cross_nic = env_vars.get("NCCL_CROSS_NIC")
+    if cross_nic is not None:
+        findings.append(f"NCCL_CROSS_NIC={cross_nic} (0=same NIC per ring, 1=allow cross-NIC, 2=auto)")
+
+    # --- NCCL_COLLNET_ENABLE ---
+    collnet = env_vars.get("NCCL_COLLNET_ENABLE")
+    if collnet is not None:
+        findings.append(f"NCCL_COLLNET_ENABLE={collnet} (InfiniBand SHARP in-network reduction)")
+
+    # --- NCCL_TOPO_FILE ---
+    topo_file = env_vars.get("NCCL_TOPO_FILE")
+    if topo_file is not None:
+        findings.append(f"NCCL_TOPO_FILE={topo_file} (custom topology XML)")
+
+    # --- NCCL_DEBUG ---
+    nccl_debug = env_vars.get("NCCL_DEBUG")
+    if nccl_debug is not None:
+        findings.append(f"NCCL_DEBUG={nccl_debug}")
+        if nccl_debug.upper() in ("INFO", "TRACE"):
+            warns.append(
+                f"NCCL_DEBUG={nccl_debug} — verbose logging adds overhead; "
+                f"use WARN for production inference"
+            )
+
+    # --- NCCL_BUFFSIZE ---
+    buffsize = env_vars.get("NCCL_BUFFSIZE")
+    if buffsize is not None:
+        findings.append(f"NCCL_BUFFSIZE={buffsize} (internal NCCL buffer size)")
+
+    # --- NCCL_GRAPH_REGISTER ---
+    graph_reg = env_vars.get("NCCL_GRAPH_REGISTER")
+    if graph_reg == "0":
+        warns.append(
+            "NCCL_GRAPH_REGISTER=0 — buffer registration for CUDA Graphs disabled; "
+            "should be 1 for best inference performance with CUDA graphs"
+        )
+
+    # --- NCCL_LAUNCH_MODE ---
+    launch_mode = env_vars.get("NCCL_LAUNCH_MODE")
+    if launch_mode is not None:
+        findings.append(f"NCCL_LAUNCH_MODE={launch_mode}")
+
+    # --- NCCL_P2P_LEVEL ---
+    p2p_level = env_vars.get("NCCL_P2P_LEVEL")
+    if p2p_level is not None:
+        findings.append(f"NCCL_P2P_LEVEL={p2p_level}")
+
+    # --- NCCL_SOCKET_NTHREADS / NCCL_NSOCKS_PERTHREAD ---
+    sock_nthreads = env_vars.get("NCCL_SOCKET_NTHREADS")
+    if sock_nthreads is not None:
+        findings.append(f"NCCL_SOCKET_NTHREADS={sock_nthreads}")
+    nsocks = env_vars.get("NCCL_NSOCKS_PERTHREAD")
+    if nsocks is not None:
+        findings.append(f"NCCL_NSOCKS_PERTHREAD={nsocks}")
+
+    # =====================================================================
+    # PyTorch distributed environment variables
+    # =====================================================================
+    master_addr = env_vars.get("MASTER_ADDR")
+    master_port = env_vars.get("MASTER_PORT")
+    world_size = env_vars.get("WORLD_SIZE")
+    rank = env_vars.get("RANK")
+    local_rank = env_vars.get("LOCAL_RANK")
+
+    torch_dist_set = any(v is not None for v in [master_addr, master_port, world_size, rank])
+    if torch_dist_set:
+        findings.append("PyTorch distributed:")
+        if master_addr:
+            findings.append(f"  MASTER_ADDR={master_addr}")
+        if master_port:
+            findings.append(f"  MASTER_PORT={master_port}")
+        if world_size:
+            findings.append(f"  WORLD_SIZE={world_size}")
+        if rank is not None:
+            findings.append(f"  RANK={rank}")
+        if local_rank is not None:
+            findings.append(f"  LOCAL_RANK={local_rank}")
+
+    # --- TORCH_DISTRIBUTED_DEBUG ---
+    torch_debug = env_vars.get("TORCH_DISTRIBUTED_DEBUG")
+    if torch_debug is not None:
+        findings.append(f"TORCH_DISTRIBUTED_DEBUG={torch_debug}")
+        if torch_debug.upper() == "DETAIL":
+            warns.append(
+                "TORCH_DISTRIBUTED_DEBUG=DETAIL — adds significant overhead; "
+                "use OFF or INFO for production inference"
+            )
+
+    # --- TORCH_NCCL_BLOCKING_WAIT ---
+    nccl_blocking = env_vars.get("TORCH_NCCL_BLOCKING_WAIT")
+    if nccl_blocking == "1":
+        warns.append(
+            "TORCH_NCCL_BLOCKING_WAIT=1 — blocks on NCCL operations, "
+            "can cause hangs; prefer async error handling"
+        )
+
+    # =====================================================================
+    # NIXL / llm-d KV cache transfer variables
+    # =====================================================================
+    nixl_vars = {k: v for k, v in env_vars.items() if k.startswith("NIXL_")}
+    if nixl_vars:
+        findings.append(f"NIXL (KV transfer): {len(nixl_vars)} variable(s) set")
+
+    nixl_etcd = env_vars.get("NIXL_ETCD_ENDPOINTS")
+    if nixl_etcd is not None:
+        findings.append(f"NIXL_ETCD_ENDPOINTS={nixl_etcd}")
+
+    nixl_ns = env_vars.get("NIXL_ETCD_NAMESPACE")
+    if nixl_ns is not None:
+        findings.append(f"NIXL_ETCD_NAMESPACE={nixl_ns}")
+
+    # Dump remaining NIXL vars
+    _handled_nixl = {"NIXL_ETCD_ENDPOINTS", "NIXL_ETCD_NAMESPACE"}
+    other_nixl = {k: v for k, v in nixl_vars.items() if k not in _handled_nixl}
+    for k, v in sorted(other_nixl.items()):
+        findings.append(f"{k}={v}")
+
+    # =====================================================================
+    # Cross-variable consistency checks
+    # =====================================================================
+
+    # Check: NCCL_IB_DISABLE=1 with RDMA devices available + multi-GPU
+    ib_disable = env_vars.get("NCCL_IB_DISABLE")
+    if ib_disable == "1" and rdma_devices and gpu_count and gpu_count > 1:
+        warns.append(
+            f"NCCL_IB_DISABLE=1 with {len(rdma_devices)} RDMA device(s) and "
+            f"{gpu_count} GPUs — inter-GPU RDMA communication disabled, "
+            f"falling back to slower socket transport"
+        )
+
+    # Check: NIXL without RDMA for disaggregated KV transfer
+    if nixl_vars and not rdma_devices:
+        warns.append(
+            "NIXL env vars set (disaggregated KV transfer) but no RDMA devices found — "
+            "KV cache transfer will use TCP, which is significantly slower"
+        )
+
+    # Check: UCX_IB_GID_INDEX vs NCCL_IB_GID_INDEX mismatch
+    ucx_gid = env_vars.get("UCX_IB_GID_INDEX")
+    nccl_gid = env_vars.get("NCCL_IB_GID_INDEX")
+    if ucx_gid is not None and nccl_gid is not None and ucx_gid != nccl_gid:
+        warns.append(
+            f"UCX_IB_GID_INDEX={ucx_gid} vs NCCL_IB_GID_INDEX={nccl_gid} — "
+            f"GID index mismatch between UCX and NCCL may cause connection failures"
+        )
+
+    return findings, warns
+
+
+def _check_gpu_numa_affinity(pod_name, gpu_labels, connections, vendor="nvidia"):
+    """Check whether GPUs in a pod are on the same NUMA node / PCIe root.
+
+    In dual-socket servers each CPU socket owns its own PCIe root complex.
+    If Kubernetes schedules a pod with GPUs on opposite sockets, the only
+    data path between them is SYS-level PCIe hops through the CPU
+    interconnect (QPI/UPI), adding latency and contention.
+
+    Returns (gpu_numa_map, warnings) where gpu_numa_map is
+    {gpu_label: numa_node} and warnings is a list of strings.
+    """
+    if not gpu_labels or len(gpu_labels) < 2:
+        return {}, []
+
+    # Get GPU bus IDs using vendor-appropriate tool, then query NUMA via sysfs
+    bus_pairs = _get_gpu_bus_ids(pod_name, vendor)
+    gpu_numa = {}
+    if bus_pairs:
+        # Batch NUMA queries in one exec
+        reads = []
+        for idx, bus_id in bus_pairs:
+            reads.append(f'echo "GPU{idx}:$(cat /sys/bus/pci/devices/{bus_id}/numa_node 2>/dev/null || echo ?)"')
+        script = "; ".join(reads) + "; true"
+        result = exec_in_pod(pod_name, ["bash", "-c", script], timeout=20, use_debug=False)
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().split("\n"):
+                line = line.strip()
+                if ":" in line:
+                    gpu_label, numa_str = line.split(":", 1)
+                    gpu_label = gpu_label.strip()
+                    try:
+                        gpu_numa[gpu_label] = int(numa_str.strip())
+                    except ValueError:
+                        gpu_numa[gpu_label] = -1
+
+    warns = []
+    if not gpu_numa:
+        return {}, []
+
+    # Check if GPUs span multiple NUMA nodes
+    numa_nodes_used = set(gpu_numa.values()) - {-1}
+    if len(numa_nodes_used) > 1:
+        # Build per-NUMA grouping
+        numa_groups = {}
+        for gpu, node in sorted(gpu_numa.items()):
+            numa_groups.setdefault(node, []).append(gpu)
+        group_strs = []
+        for node in sorted(numa_groups):
+            gpus = ", ".join(numa_groups[node])
+            group_strs.append(f"NUMA {node}: {gpus}")
+
+        warns.append(
+            f"GPUs span {len(numa_nodes_used)} NUMA nodes ({'; '.join(group_strs)}). "
+            f"Cross-socket PCIe traffic will traverse the CPU interconnect (QPI/UPI), "
+            f"adding latency and contention to GPU-GPU and GPU-NIC transfers"
+        )
+
+        # Check for SYS/PHB connections between cross-NUMA GPU pairs
+        cross_numa_sys = []
+        cross_numa_phb = []
+        seen = set()
+        for (g1, g2), conn in connections.items():
+            if g1 == g2 or conn == "X":
+                continue
+            pair = tuple(sorted([g1, g2]))
+            if pair in seen:
+                continue
+            seen.add(pair)
+            n1 = gpu_numa.get(g1)
+            n2 = gpu_numa.get(g2)
+            if n1 is not None and n2 is not None and n1 != n2:
+                if conn == "SYS":
+                    cross_numa_sys.append(pair)
+                elif conn == "PHB":
+                    cross_numa_phb.append(pair)
+
+        if cross_numa_sys:
+            pair_strs = [f"{a}<->{b}" for a, b in cross_numa_sys]
+            warns.append(
+                f"SYS connection (cross-socket): {', '.join(pair_strs)}. "
+                f"This is the worst PCIe path — data crosses the CPU "
+                f"inter-socket link, impacting allreduce/allgather latency"
+            )
+        if cross_numa_phb:
+            pair_strs = [f"{a}<->{b}" for a, b in cross_numa_phb]
+            warns.append(
+                f"PHB connection (cross PCIe root, same NUMA): {', '.join(pair_strs)}. "
+                f"Data traverses the CPU internal interconnect between PCIe root complexes"
+            )
+    elif len(numa_nodes_used) == 1:
+        # All on same NUMA — optimal
+        pass
+    # else: couldn't determine NUMA nodes
+
+    return gpu_numa, warns
+
+
+def _check_pcie_root_spread(pod_name, gpu_labels, connections, vendor="nvidia"):
+    """Check whether GPUs are spread across multiple PCIe root complexes.
+
+    On larger nodes (e.g. 8 GPUs), GPUs may be wired under different PCIe
+    root ports.  When GPUs span root complexes without NVLink/xGMI, cross-root
+    traffic must traverse the CPU's internal fabric, reducing bandwidth
+    and increasing latency for P2P transfers.
+
+    Queries each GPU's PCI topology depth to identify its root port,
+    then groups GPUs by root port.
+
+    Returns (gpu_pcie_map, warnings) where gpu_pcie_map is
+    {gpu_label: {"bus_id": ..., "root_port": ...}}
+    and warnings is a list of strings.
+    """
+    if not gpu_labels or len(gpu_labels) < 2:
+        return {}, []
+
+    # Get bus IDs using vendor-appropriate tool, then walk sysfs for root port
+    bus_pairs = _get_gpu_bus_ids(pod_name, vendor)
+    gpu_pcie = {}
+    if bus_pairs:
+        # For each GPU, walk sysfs PCI chain to find root port
+        reads = []
+        for idx, bus_id in bus_pairs:
+            reads.append(
+                f'dev_path=$(readlink -f "/sys/bus/pci/devices/{bus_id}" 2>/dev/null); '
+                f'root_port="unknown"; '
+                f'if [ -n "$dev_path" ]; then '
+                f'  chain=$(echo "$dev_path" | grep -oE "[0-9a-f]{{4}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}\\.[0-9a-f]" | head -2); '
+                f'  root_port=$(echo "$chain" | tail -1); '
+                f'fi; '
+                f'echo "GPU{idx}:{bus_id}:$root_port"'
+            )
+        script = "; ".join(reads) + "; true"
+        result = exec_in_pod(pod_name, ["bash", "-c", script], timeout=20, use_debug=False)
+        if result.returncode == 0 and result.stdout.strip():
+            for line in result.stdout.strip().split("\n"):
+                line = line.strip()
+                if not line:
+                    continue
+                # Parse GPU<idx>:<bus_id>:<root_port>
+                first_colon = line.index(":") if ":" in line else -1
+                if first_colon < 0:
+                    continue
+                gpu_label = line[:first_colon]
+                rest = line[first_colon + 1:]
+                pci_addrs = re.findall(r'[0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9a-f]', rest)
+                bus_id = pci_addrs[0] if len(pci_addrs) >= 1 else "unknown"
+                root_port = pci_addrs[1] if len(pci_addrs) >= 2 else pci_addrs[0] if pci_addrs else "unknown"
+                gpu_pcie[gpu_label] = {"bus_id": bus_id, "root_port": root_port}
+
+    warns = []
+    if not gpu_pcie or len(gpu_pcie) < 2:
+        return gpu_pcie, []
+
+    # Group GPUs by root port
+    root_groups = {}
+    for gpu, info in sorted(gpu_pcie.items()):
+        rp = info["root_port"]
+        root_groups.setdefault(rp, []).append(gpu)
+
+    if len(root_groups) > 1:
+        group_strs = []
+        for rp in sorted(root_groups):
+            gpus = ", ".join(root_groups[rp])
+            group_strs.append(f"root {rp}: {gpus}")
+
+        # Check if NVLink bridges the split
+        has_nvlink_across = False
+        for (g1, g2), conn in connections.items():
+            if g1 == g2 or conn == "X":
+                continue
+            r1 = gpu_pcie.get(g1, {}).get("root_port")
+            r2 = gpu_pcie.get(g2, {}).get("root_port")
+            if r1 and r2 and r1 != r2 and (conn.startswith("NV") or conn in ("NVL", "XGMI")):
+                has_nvlink_across = True
+                break
+
+        if has_nvlink_across:
+            warns.append(
+                f"GPUs span {len(root_groups)} PCIe root port(s) ({'; '.join(group_strs)}) "
+                f"but NVLink/xGMI bridges the gap — P2P transfers bypass PCIe"
+            )
+        else:
+            warns.append(
+                f"GPUs span {len(root_groups)} PCIe root port(s) ({'; '.join(group_strs)}). "
+                f"Without NVLink/xGMI, cross-root GPU pairs must route through the CPU's "
+                f"internal interconnect, reducing P2P bandwidth"
+            )
+
+            # Identify which GPU pairs are affected
+            cross_root_pairs = []
+            seen = set()
+            for (g1, g2), conn in connections.items():
+                if g1 == g2 or conn == "X":
+                    continue
+                pair = tuple(sorted([g1, g2]))
+                if pair in seen:
+                    continue
+                seen.add(pair)
+                r1 = gpu_pcie.get(g1, {}).get("root_port")
+                r2 = gpu_pcie.get(g2, {}).get("root_port")
+                if r1 and r2 and r1 != r2:
+                    cross_root_pairs.append((g1, g2, conn))
+            if cross_root_pairs:
+                pair_strs = [f"{a}<->{b} ({c})" for a, b, c in cross_root_pairs]
+                if len(pair_strs) <= 6:
+                    warns.append(f"Cross-root pairs: {', '.join(pair_strs)}")
+                else:
+                    warns.append(f"Cross-root pairs: {len(pair_strs)} GPU pair(s) affected")
+
+    return gpu_pcie, warns
+
+
+def _check_pcie_switch_topology(pod_name, gpu_labels, connections, gpu_pcie, vendor="nvidia"):
+    """Check for GPUs separated by PCIe switches (PXB) sharing upstream links.
+
+    Even when GPUs are on the same NUMA node and under the same PCIe root
+    complex, they may sit behind different PCIe switches.  The PXB connection
+    type in the topo matrix means GPU traffic must cross PCIe switches,
+    sharing a bottlenecked upstream link to the root complex.
+
+    This function:
+    1. Identifies PXB and PIX pairs from the topo matrix
+    2. Queries the PCIe switch (bridge) each GPU sits under
+    3. Groups GPUs by their immediate parent switch
+    4. Warns about cross-switch pairs and shared upstream bandwidth
+
+    Returns (switch_groups, warnings) where switch_groups is
+    {switch_bus_id: [gpu_labels]} and warnings is a list of strings.
+    """
+    if not gpu_labels or len(gpu_labels) < 2:
+        return {}, []
+
+    # Classify connections from the topo matrix
+    pxb_pairs = []
+    pix_pairs = []
+    phb_sys_pairs = []
+    seen = set()
+    for (g1, g2), conn in connections.items():
+        if g1 == g2 or conn == "X":
+            continue
+        pair = tuple(sorted([g1, g2]))
+        if pair in seen:
+            continue
+        seen.add(pair)
+        if conn == "PXB":
+            pxb_pairs.append((g1, g2))
+        elif conn == "PIX":
+            pix_pairs.append((g1, g2))
+        elif conn in ("PHB", "SYS", "NODE"):
+            phb_sys_pairs.append((g1, g2, conn))
+
+    # Query the PCIe switch (parent bridge) for each GPU using vendor-appropriate bus IDs
+    bus_pairs = _get_gpu_bus_ids(pod_name, vendor)
+    result_stdout = ""
+    if bus_pairs:
+        reads = []
+        for idx, bus_id in bus_pairs:
+            reads.append(
+                f'dev_path=$(readlink -f "/sys/bus/pci/devices/{bus_id}" 2>/dev/null); '
+                f'switch="unknown"; '
+                f'if [ -n "$dev_path" ]; then '
+                f'  parent=$(dirname "$dev_path"); '
+                f'  while [ "$parent" != "/sys/devices" ] && [ -n "$parent" ]; do '
+                f'    bname=$(basename "$parent"); '
+                f'    if echo "$bname" | grep -qE "^[0-9a-f]{{4}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}\\.[0-9a-f]$"; then '
+                f'      class=$(cat "$parent/class" 2>/dev/null); '
+                f'      if echo "$class" | grep -qE "^0x0604"; then '
+                f'        switch="$bname"; break; '
+                f'      fi; '
+                f'    fi; '
+                f'    parent=$(dirname "$parent"); '
+                f'  done; '
+                f'fi; '
+                f'echo "GPU{idx}:$switch"'
+            )
+        script = "; ".join(reads) + "; true"
+        result = exec_in_pod(pod_name, ["bash", "-c", script], timeout=20, use_debug=False)
+        if result.returncode == 0:
+            result_stdout = result.stdout
+
+    gpu_switch = {}  # GPU0 -> switch_bus_id
+    if result_stdout.strip():
+        for line in result_stdout.strip().split("\n"):
+            line = line.strip()
+            if ":" in line:
+                gpu_label, switch_id = line.split(":", 1)
+                gpu_switch[gpu_label.strip()] = switch_id.strip()
+
+    # Group GPUs by parent switch
+    switch_groups = {}
+    for gpu, sw in sorted(gpu_switch.items()):
+        switch_groups.setdefault(sw, []).append(gpu)
+
+    warns = []
+
+    # Report PXB connections with switch detail
+    if pxb_pairs:
+        pair_strs = [f"{a}<->{b}" for a, b in pxb_pairs]
+        if len(pair_strs) <= 6:
+            detail = ", ".join(pair_strs)
+        else:
+            detail = f"{len(pair_strs)} pair(s)"
+
+        # Build switch group description
+        known_switches = {sw: gpus for sw, gpus in switch_groups.items() if sw != "unknown"}
+        if len(known_switches) > 1:
+            sw_strs = [f"switch {sw}: {', '.join(gpus)}" for sw, gpus in sorted(known_switches.items())]
+            warns.append(
+                f"PXB: {detail} — GPUs under different PCIe switches within "
+                f"the same root complex ({'; '.join(sw_strs)}). Cross-switch "
+                f"traffic shares the upstream link to the root port, which can "
+                f"bottleneck P2P transfers and reduce effective GPU-GPU bandwidth"
+            )
+        else:
+            warns.append(
+                f"PXB: {detail} — GPUs cross PCIe switch boundaries within "
+                f"the same root complex, sharing an upstream link that can "
+                f"bottleneck P2P transfers"
+            )
+
+    # Report if some pairs are PIX (good) and others PXB (bad) — mixed switch topology
+    if pix_pairs and pxb_pairs:
+        pix_strs = [f"{a}<->{b}" for a, b in pix_pairs]
+        warns.append(
+            f"Mixed PCIe switch topology: {len(pix_pairs)} pair(s) share a switch (PIX, fast), "
+            f"{len(pxb_pairs)} pair(s) cross switches (PXB, slower upstream shared link)"
+        )
+
+    return switch_groups, warns
+
+
+def _discover_pod_topology(pod_name, short, out):
+    """Run all topology checks for a single pod.
+
+    Writes human-readable output to *out* (a file-like object).
+    Returns (pod_topo dict, list of warning strings).
+    """
+    p = out.write  # shorthand
+
+    pod_topo = {}
+    pod_warnings = []
+
+    p(f"\n--- {short} ({pod_name}) ---\n")
+
+    # Detect GPU vendor (nvidia vs amd)
+    vendor = _detect_gpu_vendor(pod_name)
+    pod_topo["gpu_vendor"] = vendor
+    if vendor == "amd":
+        amd_tool = _get_amd_tool(pod_name)
+        p(f"  GPU vendor: AMD (using {amd_tool})\n")
+    elif vendor == "nvidia":
+        p(f"  GPU vendor: NVIDIA (using nvidia-smi)\n")
+    else:
+        p(f"  GPU vendor: not detected (no nvidia-smi, rocm-smi, or amd-smi found)\n")
+
+    # 1. GPU topology matrix
+    if vendor == "nvidia":
+        topo_cmd = "nvidia-smi topo -m"
+    elif vendor == "amd":
+        topo_cmd = "amd-smi topology" if _get_amd_tool(pod_name) == "amd-smi" else "rocm-smi --showtopo"
+    else:
+        topo_cmd = "GPU topology"
+    p(f"  Checking GPU topology ({topo_cmd}) ... ")
+    topo_out, topo_ok = _get_gpu_topo(pod_name, vendor)
+    if topo_ok:
+        p("OK\n")
+        if vendor == "amd":
+            connections, gpu_labels = _parse_rocm_topo(topo_out)
+        else:
+            connections, gpu_labels = _parse_topo_matrix(topo_out)
+        has_nvlink, topo_summary = _check_nvlink_topology(connections, gpu_labels)
+        pod_topo["gpu_count"] = len(gpu_labels)
+        pod_topo["has_nvlink"] = has_nvlink
+        pod_topo["topo_summary"] = topo_summary
+        pod_topo["connections"] = connections
+        pod_topo["gpu_labels"] = gpu_labels
+
+        # Use vendor-appropriate naming
+        has_xgmi = any(c == "XGMI" for c in connections.values())
+        if has_nvlink:
+            status = "xGMI/Infinity Fabric" if has_xgmi else "NVLink/NVSwitch"
+        else:
+            status = "PCIe only"
+        p(f"    GPUs: {len(gpu_labels)}, Interconnect: {status}\n")
+        p(f"    Detail: {topo_summary}\n")
+
+        if not has_nvlink and len(gpu_labels) > 1:
+            link_name = "xGMI" if vendor == "amd" else "NVLink"
+            pod_warnings.append(f"{short}: GPUs connected via PCIe only (no {link_name})")
+
+        # Check for excessive hops between GPUs
+        hop_warns = _check_hop_distance(connections, gpu_labels)
+        if hop_warns:
+            p(f"    Hop-distance issues:\n")
+            for hw in hop_warns:
+                p(f"      {hw}\n")
+                pod_warnings.append(f"{short}: excessive hops — {hw}")
+        else:
+            if len(gpu_labels) > 1:
+                p(f"    Hop distance: OK (all pairs minimal)\n")
+
+        # Check NVSwitch domain uniformity
+        nvsw_uniform, nvsw_warns = _check_nvswitch_domains(connections, gpu_labels)
+        pod_topo["nvswitch_uniform"] = nvsw_uniform
+        if nvsw_warns:
+            p(f"    NVSwitch domain issues:\n")
+            for nw in nvsw_warns:
+                p(f"      {nw}\n")
+                pod_warnings.append(f"{short}: {nw}")
+        else:
+            if has_nvlink and len(gpu_labels) > 1:
+                p(f"    NVSwitch domain: OK (all GPUs in same domain)\n")
+
+        # Check GPU NUMA affinity (cross-socket placement)
+        gpu_numa, numa_warns = _check_gpu_numa_affinity(pod_name, gpu_labels, connections, vendor)
+        pod_topo["gpu_numa"] = gpu_numa
+        if gpu_numa:
+            numa_nodes_used = set(gpu_numa.values()) - {-1}
+            if len(numa_nodes_used) == 1:
+                p(f"    NUMA affinity: OK (all GPUs on NUMA node {next(iter(numa_nodes_used))})\n")
+            elif len(numa_nodes_used) > 1:
+                p(f"    NUMA affinity: SPLIT across {len(numa_nodes_used)} NUMA nodes\n")
+                for nw in numa_warns:
+                    p(f"      {nw}\n")
+                    pod_warnings.append(f"{short}: {nw}")
+            else:
+                p(f"    NUMA affinity: could not determine\n")
+        elif len(gpu_labels) > 1:
+            p(f"    NUMA affinity: could not query\n")
+
+        # Check PCIe root complex spread
+        gpu_pcie, pcie_root_warns = _check_pcie_root_spread(pod_name, gpu_labels, connections, vendor)
+        pod_topo["gpu_pcie"] = gpu_pcie
+        if gpu_pcie and len(gpu_labels) > 1:
+            root_ports = set(info["root_port"] for info in gpu_pcie.values()
+                             if info.get("root_port") != "unknown")
+            if len(root_ports) == 1:
+                p(f"    PCIe root:     OK (all GPUs under root port {next(iter(root_ports))})\n")
+            elif len(root_ports) > 1:
+                p(f"    PCIe root:     SPREAD across {len(root_ports)} root port(s)\n")
+                for pw in pcie_root_warns:
+                    p(f"      {pw}\n")
+                    pod_warnings.append(f"{short}: {pw}")
+            else:
+                p(f"    PCIe root:     could not determine root ports\n")
+        elif len(gpu_labels) > 1 and not gpu_pcie:
+            p(f"    PCIe root:     could not query\n")
+
+        # Check PCIe switch topology (PXB / shared upstream links)
+        switch_groups, switch_warns = _check_pcie_switch_topology(
+            pod_name, gpu_labels, connections, gpu_pcie, vendor)
+        pod_topo["pcie_switch_groups"] = switch_groups
+        if switch_warns:
+            p(f"    PCIe switches: bandwidth concern\n")
+            for sw in switch_warns:
+                p(f"      {sw}\n")
+                pod_warnings.append(f"{short}: {sw}")
+        elif len(gpu_labels) > 1 and switch_groups:
+            known = {k: v for k, v in switch_groups.items() if k != "unknown"}
+            if len(known) == 1:
+                p(f"    PCIe switches: OK (all GPUs behind same switch {next(iter(known))})\n")
+            elif len(known) == 0:
+                p(f"    PCIe switches: could not determine parent switches\n")
+            else:
+                # Multiple switches but no PXB connections — GPUs probably under different roots
+                p(f"    PCIe switches: {len(known)} switch(es) — see PCIe root above\n")
+
+        if _get_common().VERBOSE and topo_out:
+            for line in topo_out.split("\n"):
+                p(f"    | {line}\n")
+    else:
+        p("not available\n")
+        pod_topo["has_nvlink"] = None
+        pod_topo["topo_summary"] = "GPU topology tool not available"
+
+    # 2. NVLink / xGMI link status
+    if vendor == "nvidia":
+        link_cmd = "nvidia-smi nvlink --status"
+    elif vendor == "amd":
+        link_cmd = "amd-smi topology --weight" if _get_amd_tool(pod_name) == "amd-smi" else "rocm-smi --showtopoweight"
+    else:
+        link_cmd = "GPU link status"
+    p(f"  Checking link status ({link_cmd}) ... ")
+    nvlink_out, nvlink_ok = _get_gpu_link_status(pod_name, vendor)
+    if nvlink_ok:
+        p("OK\n")
+        if vendor == "amd":
+            active, inactive = _parse_rocm_link_status(nvlink_out)
+        else:
+            active, inactive = _parse_nvlink_status(nvlink_out)
+        pod_topo["nvlink_active"] = active
+        pod_topo["nvlink_inactive"] = inactive
+        p(f"    NVLink connections: {active} active, {inactive} inactive\n")
+        if inactive > 0:
+            pod_warnings.append(f"{short}: {inactive} inactive NVLink connection(s)")
+        if _get_common().VERBOSE and nvlink_out:
+            for line in nvlink_out.split("\n"):
+                p(f"    | {line}\n")
+    else:
+        p("not available\n")
+        pod_topo["nvlink_active"] = 0
+        pod_topo["nvlink_inactive"] = 0
+
+    # 3. lscpu (CPU/NUMA topology)
+    p("  Checking CPU topology (lscpu) ... ")
+    lscpu_out, lscpu_ok = _run_topo_cmd(pod_name, ["lscpu"], "lscpu")
+    lscpu_info = {}
+    if lscpu_ok:
+        p("OK\n")
+        for line in lscpu_out.split("\n"):
+            lower = line.lower()
+            if any(k in lower for k in ["socket(s)", "core(s) per socket",
+                                         "thread(s) per core", "numa node(s)",
+                                         "model name", "cpu(s):"]):
+                p(f"    {line.strip()}\n")
+                # Parse key=value
+                if ":" in line:
+                    key, _, val = line.partition(":")
+                    lscpu_info[key.strip().lower()] = val.strip()
+        if _get_common().VERBOSE:
+            for line in lscpu_out.split("\n"):
+                p(f"    | {line}\n")
+    else:
+        p("not available\n")
+    pod_topo["lscpu"] = lscpu_info
+
+    # 4. lspci -tv (PCI topology tree)
+    p("  Checking PCI topology (lspci -tv) ... ")
+    lspci_out, lspci_ok = _run_topo_cmd(pod_name, ["lspci", "-tv"], "lspci")
+    pci_gpus = []
+    pci_nics = []
+    pci_nvswitch = 0
+    if lspci_ok:
+        p("OK\n")
+        # Show NVIDIA/AMD GPU and Mellanox/ConnectX lines
+        gpu_lines = []
+        for line in lspci_out.split("\n"):
+            ll = line.lower()
+            if any(k in ll for k in ["nvidia", "mellanox", "connectx", "infiniband",
+                                      "advanced micro devices", "amd/ati", "instinct", "radeon"]):
+                gpu_lines.append(line.rstrip())
+            # Classify PCI devices
+            if "nvidia" in ll and "nvswitch" in ll:
+                pci_nvswitch += 1
+            elif "nvidia" in ll and ("h100" in ll or "a100" in ll or "h200" in ll
+                                     or "b200" in ll or "gb200" in ll or "l40" in ll
+                                     or "v100" in ll or "t4" in ll or "3d controller" in ll
+                                     or "gh100" in ll or "gh200" in ll or "ga100" in ll
+                                     or "gb100" in ll or "gb202" in ll):
+                pci_gpus.append(line.strip())
+            elif ("amd" in ll or "advanced micro" in ll) and ("instinct" in ll or "mi300" in ll
+                                     or "mi250" in ll or "mi210" in ll or "mi200" in ll
+                                     or "mi100" in ll or "display controller" in ll
+                                     or "mi308" in ll):
+                pci_gpus.append(line.strip())
+            if any(k in ll for k in ["mellanox", "connectx", "infiniband"]):
+                # Only count physical functions, not VFs
+                if "virtual function" not in ll:
+                    pci_nics.append(line.strip())
+        if gpu_lines:
+            p(f"    GPU/NIC PCI devices ({len(gpu_lines)}):\n")
+            for line in gpu_lines:
+                p(f"      {line}\n")
+        else:
+            p("    No NVIDIA/Mellanox PCI devices found in tree\n")
+        if _get_common().VERBOSE:
+            for line in lspci_out.split("\n"):
+                p(f"    | {line}\n")
+    else:
+        p("not available\n")
+    pod_topo["pci_gpu_count"] = len(pci_gpus)
+    pod_topo["pci_nic_count"] = len(pci_nics)
+    pod_topo["pci_nvswitch_count"] = pci_nvswitch
+
+    # 5. NCCL environment variable validation
+    p("  Checking NCCL environment variables ... ")
+    nccl_env = _fetch_nccl_env(pod_name)
+    rdma_devs = _fetch_rdma_devices(pod_name)
+    net_ifaces = _fetch_net_interfaces(pod_name)
+    pod_topo["nccl_env"] = nccl_env
+    pod_topo["rdma_devices"] = rdma_devs
+    if nccl_env:
+        p(f"found {len(nccl_env)} var(s)\n")
+    else:
+        p("none set\n")
+    nccl_findings, nccl_warns = _validate_nccl_env(nccl_env, rdma_devs, net_ifaces)
+    for f in nccl_findings:
+        p(f"    {f}\n")
+    for nw in nccl_warns:
+        p(f"    WARNING: {nw}\n")
+        pod_warnings.append(f"{short}: {nw}")
+
+    # 5b. vLLM / CUDA / PyTorch / NIXL environment variable validation
+    vllm_cuda_vars = {k: v for k, v in nccl_env.items()
+                      if k.startswith(("VLLM_", "CUDA_", "TORCH_", "NIXL_", "NCCL_"))
+                      or k in ("MASTER_ADDR", "MASTER_PORT", "WORLD_SIZE", "RANK", "LOCAL_RANK")}
+    if vllm_cuda_vars:
+        infer_vars = {k: v for k, v in nccl_env.items()
+                      if k.startswith(("VLLM_", "CUDA_", "TORCH_", "NIXL_"))
+                      or k in ("MASTER_ADDR", "MASTER_PORT", "WORLD_SIZE", "RANK", "LOCAL_RANK")}
+        if infer_vars:
+            p(f"  Checking vLLM/CUDA/PyTorch/NIXL environment ... found {len(infer_vars)} var(s)\n")
+        else:
+            p(f"  Checking vLLM/CUDA/PyTorch/NIXL environment ... none set\n")
+        gpu_count_val = pod_topo.get("gpu_count", 0)
+        has_nvlink_val = pod_topo.get("has_nvlink", False)
+        vcn_findings, vcn_warns = _validate_vllm_cuda_env(
+            nccl_env, gpu_count_val, rdma_devs, has_nvlink_val)
+        for f in vcn_findings:
+            p(f"    {f}\n")
+        for vw in vcn_warns:
+            p(f"    WARNING: {vw}\n")
+            pod_warnings.append(f"{short}: {vw}")
+    else:
+        p("  Checking vLLM/CUDA/PyTorch/NIXL environment ... none set\n")
+
+    # 6. RDMA NIC status (ibstat or sysfs fallback)
+    if rdma_devs:
+        p("  Checking RDMA NIC status ... ")
+        nic_status = _fetch_rdma_nic_status(pod_name, rdma_devs)
+        pod_topo["nic_status"] = nic_status
+        if nic_status:
+            source = next(iter(nic_status.values())).get("source", "unknown")
+            p(f"OK (via {source}, {len(nic_status)} device(s))\n")
+
+            # Summarize: group by state
+            state_counts = {}
+            down_devs = []
+            for dev, info in sorted(nic_status.items()):
+                state = info.get("state", "?")
+                state_counts[state] = state_counts.get(state, 0) + 1
+                if "active" not in state.lower() and state != "?":
+                    down_devs.append(dev)
+
+            state_str = ", ".join(f"{s}: {c}" for s, c in sorted(state_counts.items()))
+            p(f"    Port states: {state_str}\n")
+
+            if down_devs:
+                if len(down_devs) <= 8:
+                    p(f"    WARNING: non-active devices: {', '.join(down_devs)}\n")
+                else:
+                    p(f"    WARNING: {len(down_devs)} device(s) not in ACTIVE state\n")
+                pod_warnings.append(
+                    f"{short}: {len(down_devs)} RDMA device(s) not in ACTIVE state: "
+                    f"{', '.join(down_devs[:8])}{'...' if len(down_devs) > 8 else ''}"
+                )
+
+            # Show rate for first active device
+            for dev, info in sorted(nic_status.items()):
+                if "active" in info.get("state", "").lower():
+                    rate = info.get("rate", "?")
+                    link = info.get("link_layer", "?")
+                    fw = info.get("fw_ver", "?")
+                    p(f"    Sample ({dev}): rate={rate}, link_layer={link}, fw={fw}\n")
+                    break
+
+            if _get_common().VERBOSE:
+                for dev, info in sorted(nic_status.items()):
+                    parts = [f"{k}={v}" for k, v in sorted(info.items()) if k != "source"]
+                    p(f"    | {dev}: {', '.join(parts)}\n")
+        else:
+            p("could not query\n")
+            pod_topo["nic_status"] = {}
+    else:
+        pod_topo["nic_status"] = {}
+
+    return pod_topo, pod_warnings
+
+
+def run_topology_validation(pods, display_names):
+    """Run GPU topology checks on all pods in parallel.
+
+    Each pod runs in its own thread.  Output is printed in pod order:
+    the first pod's output streams live, then the second pod's buffered
+    output is flushed (possibly already complete), and so on.
+    """
+    print(f"\n{'=' * 60}")
+    print("  GPU TOPOLOGY VALIDATION")
+    print(f"{'=' * 60}")
+
+    n = len(pods)
+    _StreamingBuffer = _get_common()._StreamingBuffer
+    buffers = [_StreamingBuffer() for _ in range(n)]
+    results = [None] * n      # (pod_topo, pod_warnings)
+    done_events = [threading.Event() for _ in range(n)]
+
+    def _worker(idx, pod_name, short, buf, done_evt):
+        try:
+            topo, warns = _discover_pod_topology(pod_name, short, buf)
+            results[idx] = (topo, warns)
+        except Exception as exc:
+            buf.write(f"\n  ERROR discovering {short}: {exc}\n")
+            results[idx] = ({}, [f"{short}: discovery failed — {exc}"])
+        finally:
+            done_evt.set()
+
+    # Launch all threads
+    threads = []
+    for i, (pod_name, _ip) in enumerate(pods):
+        short = display_names[pod_name]
+        t = threading.Thread(
+            target=_worker,
+            args=(i, pod_name, short, buffers[i], done_events[i]),
+            daemon=True,
+        )
+        threads.append(t)
+        t.start()
+
+    # Print output in pod order: stream pod i, then move to pod i+1
+    all_pod_results = {}
+    warnings = []
+    for i, (pod_name, _ip) in enumerate(pods):
+        # Stream live output for this pod while its thread is running
+        while not done_events[i].is_set():
+            buffers[i].flush_new()
+            done_events[i].wait(timeout=0.1)
+        # Final flush — thread is done, print any remaining output
+        buffers[i].flush_all()
+
+        if results[i] is not None:
+            pod_topo, pod_warns = results[i]
+            all_pod_results[pod_name] = pod_topo
+            warnings.extend(pod_warns)
+        else:
+            all_pod_results[pod_name] = {}
+
+    # Wait for all threads to finish (should already be done)
+    for t in threads:
+        t.join(timeout=5)
+
+    # Cross-pod consistency checks
+    _nccl_key_vars = ["NCCL_IB_HCA", "NCCL_IB_DISABLE", "NCCL_SOCKET_IFNAME",
+                       "NCCL_EXCLUDE_IB_HCA", "NCCL_NET", "NCCL_IB_GID_INDEX",
+                       "NCCL_NET_GDR_LEVEL", "NCCL_IB_TC", "NCCL_IB_TIMEOUT",
+                       "NCCL_P2P_DISABLE", "NCCL_SHM_DISABLE", "NCCL_ALGO",
+                       "NCCL_PROTO", "NCCL_MAX_CTAS", "NCCL_NVLS_ENABLE",
+                       "NCCL_CROSS_NIC", "NCCL_DEBUG", "NCCL_TOPO_FILE",
+                       "UCX_TLS", "UCX_NET_DEVICES", "UCX_MAX_RNDV_RAILS",
+                       "UCX_RNDV_THRESH", "UCX_MEMTYPE_CACHE", "UCX_IB_GID_INDEX",
+                       "CUDA_VISIBLE_DEVICES", "CUDA_DEVICE_ORDER",
+                       "CUDA_MODULE_LOADING",
+                       "VLLM_HOST_IP", "VLLM_DISABLE_PYNCCL",
+                       "VLLM_DP_SIZE", "VLLM_TARGET_DEVICE",
+                       "VLLM_WORKER_MULTIPROC_METHOD",
+                       "NIXL_ETCD_ENDPOINTS", "NIXL_ETCD_NAMESPACE"]
+
+    env_mismatches = {}  # var -> {value -> [pod_short_names]}
+    rdma_vals = {}       # tuple(device_list) -> [pod_short_names]
+    if len(pods) > 1:
+        for var in _nccl_key_vars:
+            vals = {}
+            for pod_name, _ip in pods:
+                v = all_pod_results[pod_name].get("nccl_env", {}).get(var)
+                vals.setdefault(v, []).append(display_names[pod_name])
+            if len(vals) > 1:
+                env_mismatches[var] = vals
+                parts = []
+                for v, pod_list in sorted(vals.items(), key=lambda x: x[0] or ""):
+                    display_val = v if v is not None else "<unset>"
+                    parts.append(f"{display_val} on {', '.join(pod_list)}")
+                warnings.append(f"MISMATCH: {var} differs across pods: {'; '.join(parts)}")
+
+        # Check RDMA device list consistency
+        rdma_vals = {}
+        for pod_name, _ip in pods:
+            devs = tuple(all_pod_results[pod_name].get("rdma_devices", []))
+            rdma_vals.setdefault(devs, []).append(display_names[pod_name])
+        if len(rdma_vals) > 1:
+            parts = []
+            for devs, pod_list in rdma_vals.items():
+                dev_str = ", ".join(devs) if devs else "<none>"
+                parts.append(f"{len(devs)} device(s) on {', '.join(pod_list)}")
+            warnings.append(f"MISMATCH: RDMA device lists differ across pods: {'; '.join(parts)}")
+
+    # Topology connection type legend
+    print(f"\n{'─' * 50}")
+    print("  GPU Topology Connection Type Legend")
+    print(f"{'─' * 50}")
+    print("  High-bandwidth GPU interconnects:")
+    print("    NV#   = NVIDIA NVLink with # lanes (e.g. NV12 = 12 lanes, NV18 = 18).")
+    print("            Routed through NVSwitch on multi-GPU systems.")
+    print("    NVL   = NVIDIA NVLink (alternate notation in some driver versions)")
+    print("    XGMI  = AMD Infinity Fabric / xGMI link (direct GPU-GPU interconnect)")
+    print()
+    print("  PCIe paths (lower bandwidth, higher latency):")
+    print("    PIX   = same PCIe switch (1 PCIe hop, best PCIe path)")
+    print("    PXB   = cross PCIe switch, same PCIe root complex (2 PCIe hops)")
+    print("    PHB   = same CPU/NUMA node but different PCIe root complex (traverses")
+    print("            the CPU's internal interconnect)")
+    print("    NODE  = same NUMA node (legacy alias, similar to PHB)")
+    print("    SYS   = cross-socket / cross-NUMA (worst path — traverses QPI/UPI")
+    print("            inter-CPU link, highest latency)")
+    print()
+    print("  Readiness:")
+    print("    NVLink/xGMI-READY = all GPU pairs connected via NV#/NVL/XGMI — optimal")
+    print("                        for collective operations (allreduce, allgather)")
+    print("    PCIe only         = no high-bandwidth GPU interconnect — communication")
+    print("                        goes through PCIe, significantly lower bandwidth")
+    print()
+    print("  Commands: nvidia-smi topo -m (NVIDIA) | rocm-smi --showtopo / amd-smi topology (AMD)")
+
+    # Cross-pod comparison
+    print(f"\n{'─' * 50}")
+    print("  Topology Summary")
+    print(f"{'─' * 50}")
+
+    for pod_name, _ip in pods:
+        short = display_names[pod_name]
+        topo = all_pod_results[pod_name]
+        gpu_count = topo.get("gpu_count", "?")
+        has_nvlink = topo.get("has_nvlink")
+        if has_nvlink is True:
+            link_str = "NVLink/NVSwitch"
+        elif has_nvlink is False:
+            link_str = "PCIe only"
+        else:
+            link_str = "unknown"
+        nvl_active = topo.get("nvlink_active", 0)
+        nvl_inactive = topo.get("nvlink_inactive", 0)
+        nvsw_ok = topo.get("nvswitch_uniform")
+        nvsw_str = ""
+        if nvsw_ok is True:
+            nvsw_str = "  NVSwitch=uniform"
+        elif nvsw_ok is False:
+            nvsw_str = "  NVSwitch=SPLIT"
+        gpu_numa = topo.get("gpu_numa", {})
+        numa_nodes_used = set(gpu_numa.values()) - {-1} if gpu_numa else set()
+        numa_str = ""
+        if len(numa_nodes_used) == 1:
+            numa_str = f"  NUMA={next(iter(numa_nodes_used))}"
+        elif len(numa_nodes_used) > 1:
+            numa_str = f"  NUMA=SPLIT({','.join(str(n) for n in sorted(numa_nodes_used))})"
+        gpu_pcie = topo.get("gpu_pcie", {})
+        root_ports = set(info["root_port"] for info in gpu_pcie.values()
+                         if info.get("root_port") != "unknown") if gpu_pcie else set()
+        pcie_root_str = ""
+        if len(root_ports) == 1:
+            pcie_root_str = f"  PCIe=1root"
+        elif len(root_ports) > 1:
+            pcie_root_str = f"  PCIe={len(root_ports)}roots"
+        print(f"  {short:{_get_common().DISPLAY_NAME_MAX_LEN}s}  GPUs={gpu_count}  "
+              f"Interconnect={link_str}  NVLinks={nvl_active} active/{nvl_inactive} inactive"
+              f"{nvsw_str}{numa_str}{pcie_root_str}")
+
+    # Check consistency across pods
+    nvlink_states = set()
+    gpu_counts = set()
+    nvswitch_states = set()
+    for topo in all_pod_results.values():
+        if topo.get("has_nvlink") is not None:
+            nvlink_states.add(topo["has_nvlink"])
+        if "gpu_count" in topo:
+            gpu_counts.add(topo["gpu_count"])
+        if topo.get("nvswitch_uniform") is not None:
+            nvswitch_states.add(topo["nvswitch_uniform"])
+
+    if len(nvlink_states) > 1:
+        warnings.append("MISMATCH: pods have different GPU interconnect types (some NVLink, some PCIe)")
+    if len(gpu_counts) > 1:
+        warnings.append(f"MISMATCH: pods have different GPU counts: {sorted(gpu_counts)}")
+    if nvswitch_states == {True, False}:
+        warnings.append("MISMATCH: some pods have uniform NVSwitch domains, others have split domains")
+
+    if warnings:
+        print(f"\n  Topology Warnings:")
+        for w in warnings:
+            print(f"    WARNING: {w}")
+    else:
+        print(f"\n  No topology warnings.")
+
+    # Detailed environment consistency diff
+    has_any_inconsistency = (env_mismatches or len(gpu_counts) > 1
+                             or len(nvlink_states) > 1 or len(rdma_vals) > 1)
+    if len(pods) > 1:
+        print(f"\n{'─' * 50}")
+        print("  Cross-Pod Consistency Check")
+        print(f"{'─' * 50}")
+
+        pod_shorts = [display_names[p] for p, _ in pods]
+        name_w = max(len(s) for s in pod_shorts)
+
+        if has_any_inconsistency:
+            # GPU count consistency
+            if len(gpu_counts) > 1:
+                print(f"\n  GPU count (INCONSISTENT):")
+                for pod_name, _ip in pods:
+                    short = display_names[pod_name]
+                    gc = all_pod_results[pod_name].get("gpu_count", "?")
+                    print(f"    {short:{name_w}s}  {gc}")
+
+            # Interconnect type consistency
+            if len(nvlink_states) > 1:
+                print(f"\n  GPU interconnect (INCONSISTENT):")
+                for pod_name, _ip in pods:
+                    short = display_names[pod_name]
+                    hnv = all_pod_results[pod_name].get("has_nvlink")
+                    label = "NVLink" if hnv is True else "PCIe only" if hnv is False else "unknown"
+                    print(f"    {short:{name_w}s}  {label}")
+
+            # RDMA device list consistency
+            if len(rdma_vals) > 1:
+                print(f"\n  RDMA devices (INCONSISTENT):")
+                for pod_name, _ip in pods:
+                    short = display_names[pod_name]
+                    devs = all_pod_results[pod_name].get("rdma_devices", [])
+                    print(f"    {short:{name_w}s}  {len(devs)} device(s): {', '.join(devs[:5])}"
+                          f"{'...' if len(devs) > 5 else ''}")
+
+            # NCCL env var diff table
+            if env_mismatches:
+                print(f"\n  Environment variables (INCONSISTENT):")
+                for var, val_map in env_mismatches.items():
+                    print(f"\n    {var}:")
+                    for pod_name, _ip in pods:
+                        short = display_names[pod_name]
+                        v = all_pod_results[pod_name].get("nccl_env", {}).get(var)
+                        display_val = v if v is not None else "<unset>"
+                        # Truncate long values for readability
+                        if len(display_val) > 60:
+                            display_val = display_val[:57] + "..."
+                        print(f"      {short:{name_w}s}  {display_val}")
+        else:
+            # All consistent — print summary
+            checks_ok = []
+            if len(gpu_counts) <= 1:
+                checks_ok.append("GPU count")
+            if len(nvlink_states) <= 1:
+                checks_ok.append("GPU interconnect")
+            if len(rdma_vals) <= 1:
+                checks_ok.append("RDMA devices")
+            checks_ok.append("env vars (NCCL/UCX/CUDA/vLLM/NIXL)")
+            print(f"  All {len(pods)} pods are consistent: {', '.join(checks_ok)}")
+
+    # Pod hardware profile summary
+    print(f"\n{'─' * 50}")
+    print("  Pod Hardware Profile")
+    print(f"{'─' * 50}")
+
+    # Classify pods by role (from pod name patterns)
+    pod_roles = {}  # role -> [pod_short_names]
+    for pod_name, _ip in pods:
+        short = display_names[pod_name]
+        name_lower = pod_name.lower()
+        if "prefill" in name_lower:
+            pod_roles.setdefault("prefill", []).append(short)
+        elif "decode" in name_lower:
+            pod_roles.setdefault("decode", []).append(short)
+        else:
+            pod_roles.setdefault("other", []).append(short)
+
+    if pod_roles:
+        role_parts = []
+        for role in ["prefill", "decode", "other"]:
+            if role in pod_roles:
+                role_parts.append(f"{len(pod_roles[role])} {role}")
+        print(f"  Pod types:         {', '.join(role_parts)} ({len(pods)} total)")
+        if not _get_common().SSH_MODE:
+            ns_flag = f" -n {_get_common().OPT_NAMESPACE}" if _get_common().OPT_NAMESPACE else ""
+            explain_cmd(f"kubectl get pods{ns_flag} -l {_get_common().OPT_LABEL} -o json | jq '.items[].metadata.name'",
+                        "pod names contain role hints (prefill, decode, etc.)")
+
+    # Use first pod as representative (all should be consistent by this point)
+    sample = next(iter(all_pod_results.values())) if all_pod_results else {}
+    sample_pod = pods[0][0] if pods else "<POD>"
+    kx = _kubectl_exec_prefix(sample_pod)
+    lscpu = sample.get("lscpu", {})
+
+    # CPU/NUMA
+    cpu_model = lscpu.get("model name", "unknown")
+    sockets = lscpu.get("socket(s)", "?")
+    cores_per = lscpu.get("core(s) per socket", "?")
+    threads_per = lscpu.get("thread(s) per core", "?")
+    numa_nodes = lscpu.get("numa node(s)", "?")
+    total_cpus = lscpu.get("cpu(s)", "?")
+    if cpu_model != "unknown":
+        print(f"  CPU:               {cpu_model}")
+    print(f"  NUMA:              {numa_nodes} node(s), {sockets} socket(s), "
+          f"{cores_per} cores/socket, {threads_per} threads/core, {total_cpus} logical CPUs")
+    explain_cmd(f"{kx} lscpu | grep -iE 'socket|core|thread|numa|model name|^cpu\\(s\\)'",
+                "parse Socket(s), Core(s) per socket, NUMA node(s), Model name")
+
+    # GPUs
+    gpu_count = sample.get("gpu_count", 0)
+    pci_gpu_total = sample.get("pci_gpu_count", 0)
+    pci_nvswitch = sample.get("pci_nvswitch_count", 0)
+    has_nvlink = sample.get("has_nvlink")
+
+    # Try to get GPU model from lspci data
+    gpu_model = "unknown"
+    sample_vendor = sample.get("gpu_vendor", "unknown")
+    for pod_name, _ip in pods:
+        if sample_vendor == "amd":
+            result = exec_in_pod(
+                pod_name,
+                ["bash", "-c", "lspci 2>/dev/null | grep -iE 'amd|instinct|advanced micro' "
+                 "| grep -iv bridge | head -1; true"],
+                timeout=15, use_debug=False,
+            )
+        else:
+            result = exec_in_pod(
+                pod_name,
+                ["bash", "-c", "lspci 2>/dev/null | grep -i nvidia | grep -iv nvswitch | head -1; true"],
+                timeout=15, use_debug=False,
+            )
+        if result.returncode == 0 and result.stdout.strip():
+            line = result.stdout.strip()
+            for marker in ["NVIDIA Corporation ", "Advanced Micro Devices, Inc. ",
+                           "AMD/ATI "]:
+                if marker in line:
+                    gpu_model = line.split(marker, 1)[1].strip()
+                    break
+            if gpu_model != "unknown":
+                break
+
+    if gpu_model != "unknown":
+        print(f"  GPU:               {gpu_count} assigned to pod, model: {gpu_model}")
+    else:
+        print(f"  GPU:               {gpu_count} assigned to pod")
+    explain_cmd(f"{kx} nvidia-smi topo -m",
+                "count GPU rows (GPU0, GPU1, ...) for assigned GPUs")
+    explain_cmd(f"{kx} bash -c \"lspci | grep -i nvidia | grep -iv nvswitch\"",
+                "count lines for total GPUs on host PCI bus; extract model from description")
+    if pci_gpu_total > gpu_count:
+        print(f"                     ({pci_gpu_total} GPUs visible in PCI bus on host)")
+    if pci_nvswitch > 0:
+        print(f"  NVSwitch:          {pci_nvswitch} ASIC(s) on host PCI bus")
+        explain_cmd(f"{kx} bash -c \"lspci | grep -i nvswitch | wc -l\"",
+                    "count NVSwitch ASICs visible in PCI bus")
+    if has_nvlink is True:
+        print(f"  GPU interconnect:  NVLink/NVSwitch (high-bandwidth GPU-GPU fabric)")
+    elif has_nvlink is False:
+        print(f"  GPU interconnect:  PCIe only (no NVLink between assigned GPUs)")
+    else:
+        print(f"  GPU interconnect:  unknown")
+    explain_cmd(f"{kx} nvidia-smi topo -m",
+                "if all GPU pairs show NV## (e.g. NV12, NV18) = NVLink; PIX/PXB/PHB/SYS = PCIe")
+
+    # RDMA / InfiniBand / RoCE
+    rdma_devs = sample.get("rdma_devices", [])
+    nccl_env = sample.get("nccl_env", {})
+    exclude_hca = nccl_env.get("NCCL_EXCLUDE_IB_HCA", "")
+    ib_hca = nccl_env.get("NCCL_IB_HCA", "")
+    ib_disabled = nccl_env.get("NCCL_IB_DISABLE") == "1"
+
+    pci_nic_count = sample.get("pci_nic_count", 0)
+    if rdma_devs:
+        # Determine link layer type by checking a device
+        link_type = "unknown"
+        for pod_name, _ip in pods:
+            result = exec_in_pod(
+                pod_name,
+                ["bash", "-c",
+                 f"cat /sys/class/infiniband/{rdma_devs[0]}/ports/1/link_layer 2>/dev/null; true"],
+                timeout=10, use_debug=False,
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                link_type = result.stdout.strip()  # "Ethernet" (RoCE) or "InfiniBand"
+                break
+
+        if link_type.lower() == "ethernet":
+            rdma_type = "RoCE (RDMA over Converged Ethernet)"
+        elif link_type.lower() == "infiniband":
+            rdma_type = "InfiniBand"
+        else:
+            rdma_type = link_type
+
+        active_count = len(rdma_devs)
+        if exclude_hca:
+            excluded = len([x for x in exclude_hca.split(",") if x.strip()])
+            active_count = len(rdma_devs) - excluded
+        elif ib_hca:
+            active_count = len([x for x in ib_hca.split(",") if x.strip()])
+
+        print(f"  RDMA:              {len(rdma_devs)} device(s), {active_count} active for NCCL")
+        explain_cmd(f"{kx} bash -c \"ibv_devices 2>/dev/null || ls /sys/class/infiniband/\"",
+                    "ibv_devices preferred; fallback to sysfs listing")
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^NCCL_(IB_HCA|EXCLUDE_IB_HCA|IB_DISABLE)'\"",
+                    "NCCL_EXCLUDE_IB_HCA excludes devices; NCCL_IB_HCA selects; usable = total - excluded")
+        print(f"  Link layer:        {rdma_type}")
+
+        # RDMA NIC status from ibstat or sysfs
+        sample_nic_status = sample.get("nic_status", {})
+        if sample_nic_status:
+            source = next(iter(sample_nic_status.values())).get("source", "unknown")
+            state_counts = {}
+            for dev, info in sample_nic_status.items():
+                state = info.get("state", "?")
+                state_counts[state] = state_counts.get(state, 0) + 1
+            state_str = ", ".join(f"{s}: {c}" for s, c in sorted(state_counts.items()))
+            print(f"  NIC port states:   {state_str} (via {source})")
+            # Show rate from first active NIC
+            for dev, info in sorted(sample_nic_status.items()):
+                if "active" in info.get("state", "").lower():
+                    rate = info.get("rate", "?")
+                    fw = info.get("fw_ver", "?")
+                    ca_type = info.get("ca_type", "")
+                    rate_parts = [f"rate={rate}"]
+                    if ca_type:
+                        rate_parts.append(f"type={ca_type}")
+                    rate_parts.append(f"fw={fw}")
+                    print(f"  NIC detail:        {', '.join(rate_parts)} ({dev})")
+                    break
+            explain_cmd(f"{kx} ibstat {rdma_devs[0]} 2>/dev/null",
+                        "ibstat shows CA type, port state, physical state, rate, link layer, firmware")
+            explain_cmd(f"{kx} bash -c \"cat /sys/class/infiniband/{rdma_devs[0]}/ports/1/{{state,phys_state,rate,link_layer}}\"",
+                        "sysfs fallback: read port attributes directly")
+        else:
+            explain_cmd(f"{kx} cat /sys/class/infiniband/{rdma_devs[0]}/ports/1/link_layer",
+                        "Ethernet = RoCE; InfiniBand = native IB")
+
+        if pci_nic_count > 0:
+            print(f"  Network NICs:      {pci_nic_count} physical NIC(s) in PCI bus")
+            explain_cmd(f"{kx} bash -c \"lspci -tv | grep -iE 'mellanox|connectx|infiniband' | grep -v 'Virtual Function'\"",
+                        "count physical (non-VF) Mellanox/ConnectX NICs")
+        if ib_disabled:
+            print(f"  IB/RoCE status:    DISABLED (NCCL_IB_DISABLE=1)")
+        else:
+            print(f"  IB/RoCE status:    enabled")
+        explain_cmd(f"{kx} bash -c \"env | grep NCCL_IB_DISABLE\"",
+                    "if =1, IB/RoCE disabled; if unset or =0, enabled")
+    else:
+        print(f"  RDMA:              no devices found")
+        explain_cmd(f"{kx} bash -c \"ls /sys/class/infiniband/ 2>/dev/null\"",
+                    "empty = no RDMA devices")
+        if pci_nic_count > 0:
+            print(f"  Network NICs:      {pci_nic_count} physical NIC(s) in PCI bus")
+
+    # Connection type matrix per pod type
+    if len(pods) > 1 and pod_roles:
+        print(f"\n{'─' * 50}")
+        print("  Connection Type Matrix by Pod Type")
+        print(f"{'─' * 50}")
+
+        # Build per-role summaries
+        role_order = [r for r in ["prefill", "decode", "other"] if r in pod_roles]
+        # Collect per-pod-name -> role mapping
+        pod_to_role = {}
+        for pod_name, _ip in pods:
+            name_lower = pod_name.lower()
+            if "prefill" in name_lower:
+                pod_to_role[pod_name] = "prefill"
+            elif "decode" in name_lower:
+                pod_to_role[pod_name] = "decode"
+            else:
+                pod_to_role[pod_name] = "other"
+
+        for role in role_order:
+            role_pods = [(pn, ip) for pn, ip in pods if pod_to_role.get(pn) == role]
+            print(f"\n  {role.upper()} pods ({len(role_pods)}):")
+
+            # GPU interconnect for this role
+            role_conn_types = set()
+            role_gpu_counts = set()
+            for pn, _ in role_pods:
+                topo = all_pod_results.get(pn, {})
+                role_gpu_counts.add(topo.get("gpu_count", 0))
+                for (g1, g2), conn in topo.get("connections", {}).items():
+                    if g1 != g2 and conn != "X":
+                        role_conn_types.add(conn)
+
+            nv_conns = sorted(c for c in role_conn_types if c.startswith("NV") or c == "NVL")
+            pcie_conns = sorted(c for c in role_conn_types if c in {"PIX", "PXB", "PHB", "NODE", "SYS"})
+
+            gc_str = "/".join(str(g) for g in sorted(role_gpu_counts))
+            print(f"    GPUs per pod:    {gc_str}")
+
+            if nv_conns and not pcie_conns:
+                print(f"    GPU group:       NVLink-READY ({', '.join(nv_conns)})")
+            elif nv_conns and pcie_conns:
+                print(f"    GPU group:       mixed NVLink ({', '.join(nv_conns)}) + PCIe ({', '.join(pcie_conns)})")
+            elif pcie_conns:
+                print(f"    GPU group:       PCIe only ({', '.join(pcie_conns)})")
+            else:
+                print(f"    GPU group:       no inter-GPU connections detected")
+
+            # Network/RDMA for this role
+            role_rdma_counts = set()
+            role_active_counts = set()
+            role_link_layers = set()
+            for pn, _ in role_pods:
+                topo = all_pod_results.get(pn, {})
+                devs = topo.get("rdma_devices", [])
+                role_rdma_counts.add(len(devs))
+                env = topo.get("nccl_env", {})
+                excl = env.get("NCCL_EXCLUDE_IB_HCA", "")
+                hca = env.get("NCCL_IB_HCA", "")
+                if hca:
+                    role_active_counts.add(len([x for x in hca.split(",") if x.strip()]))
+                elif excl:
+                    role_active_counts.add(len(devs) - len([x for x in excl.split(",") if x.strip()]))
+                else:
+                    role_active_counts.add(len(devs))
+
+            rdma_str = "/".join(str(r) for r in sorted(role_rdma_counts))
+            active_str = "/".join(str(a) for a in sorted(role_active_counts))
+            print(f"    RDMA devices:    {rdma_str} total, {active_str} active for NCCL")
+
+            # Link layer (use first pod of this role)
+            first_pn = role_pods[0][0]
+            first_devs = all_pod_results.get(first_pn, {}).get("rdma_devices", [])
+            if first_devs:
+                result = exec_in_pod(
+                    first_pn,
+                    ["bash", "-c",
+                     f"cat /sys/class/infiniband/{first_devs[0]}/ports/1/link_layer 2>/dev/null; true"],
+                    timeout=10, use_debug=False,
+                )
+                ll = result.stdout.strip() if result.returncode == 0 else "unknown"
+                if ll.lower() == "ethernet":
+                    print(f"    Network group:   RoCE (RDMA over Converged Ethernet)")
+                elif ll.lower() == "infiniband":
+                    print(f"    Network group:   InfiniBand (native IB fabric)")
+                else:
+                    print(f"    Network group:   {ll}")
+            else:
+                print(f"    Network group:   no RDMA devices")
+
+            ib_dis = any(
+                all_pod_results.get(pn, {}).get("nccl_env", {}).get("NCCL_IB_DISABLE") == "1"
+                for pn, _ in role_pods
+            )
+            if ib_dis:
+                print(f"    IB/RoCE:         DISABLED on some/all pods")
+            else:
+                print(f"    IB/RoCE:         enabled")
+
+    # High-level findings summary
+    print(f"\n{'─' * 50}")
+    print("  High-Level Findings")
+    print(f"{'─' * 50}")
+
+    # Collect aggregate data
+    all_gpu_counts = [t.get("gpu_count", 0) for t in all_pod_results.values() if "gpu_count" in t]
+    all_has_nvlink = [t.get("has_nvlink") for t in all_pod_results.values()]
+    all_nvl_active = [t.get("nvlink_active", 0) for t in all_pod_results.values()]
+    all_nvswitch_uniform = [t.get("nvswitch_uniform") for t in all_pod_results.values()]
+
+    # Collect all connection types observed across pods (excluding self/X)
+    all_conn_types = set()
+    for t in all_pod_results.values():
+        for (g1, g2), conn in t.get("connections", {}).items():
+            if g1 != g2 and conn != "X":
+                all_conn_types.add(conn)
+
+    # Check lspci for NVSwitch ASICs across pods
+    nvswitch_in_pci = False
+    for pod_name, _ip in pods:
+        result = exec_in_pod(
+            pod_name,
+            ["bash", "-c", "lspci 2>/dev/null | grep -ci nvswitch; true"],
+            timeout=15, use_debug=False,
+        )
+        if result.returncode == 0:
+            try:
+                count = int(result.stdout.strip())
+                if count > 0:
+                    nvswitch_in_pci = True
+                    break
+            except ValueError:
+                pass
+
+    num_pods = len(pods)
+
+    # GPU count
+    if all_gpu_counts:
+        if len(set(all_gpu_counts)) == 1:
+            print(f"  GPU allocation:    {all_gpu_counts[0]} GPU(s) per pod, consistent across all {num_pods} pod(s)")
+        else:
+            print(f"  GPU allocation:    varies across pods — {dict(zip([display_names[p] for p, _ in pods], all_gpu_counts))}")
+    explain_cmd(f"{kx} nvidia-smi topo -m | grep -c '^GPU'",
+                "count topo matrix rows to determine how many accelerators are assigned to the pod")
+
+    # Interconnect + NVLink-readiness assessment
+    nvlink_pods = sum(1 for v in all_has_nvlink if v is True)
+    pcie_pods = sum(1 for v in all_has_nvlink if v is False)
+
+    # Classify observed connection types
+    nv_types = sorted(c for c in all_conn_types if c.startswith("NV") or c == "NVL")
+    pcie_types_seen = sorted(c for c in all_conn_types if c in {"PIX", "PXB", "PHB", "NODE", "SYS"})
+    other_types = sorted(all_conn_types - set(nv_types) - set(pcie_types_seen))
+
+    if all_conn_types:
+        print(f"  Connection types:  {', '.join(sorted(all_conn_types))} observed across all GPU pairs")
+    else:
+        if all_gpu_counts and max(all_gpu_counts) <= 1:
+            print(f"  Connection types:  N/A — single GPU per pod, no inter-GPU connections")
+        else:
+            print(f"  Connection types:  none detected")
+    explain_cmd(f"{kx} nvidia-smi topo -m",
+                "read the matrix values between GPU rows: NV## = NVLink, PIX/PXB/PHB/SYS = PCIe paths, X = self")
+
+    if nvlink_pods == num_pods:
+        print(f"  GPU interconnect:  NVLink/NVSwitch on all {num_pods} pod(s)")
+        # Check if ALL GPU pairs use NVLink (fully NVLink-ready)
+        if pcie_types_seen:
+            print(f"                     PARTIAL: some GPU pairs still use PCIe paths ({', '.join(pcie_types_seen)})")
+            print(f"                     Not all GPU pairs are NVLink-connected")
+        else:
+            # All pairs connected via NV#
+            if nv_types:
+                widths = []
+                for nt in nv_types:
+                    suffix = nt[2:]
+                    if suffix.isdigit():
+                        widths.append(f"{nt} = {suffix} NVLink lanes")
+                    elif nt == "NVL":
+                        widths.append("NVL = NVLink")
+                width_desc = ", ".join(widths) if widths else ", ".join(nv_types)
+                print(f"                     NVLink-READY: all GPU pairs connected via NVLink ({width_desc})")
+            else:
+                print(f"                     NVLink-READY: all GPU pairs connected via NVLink")
+    elif pcie_pods == num_pods:
+        print(f"  GPU interconnect:  PCIe only on all {num_pods} pod(s)")
+        if nvswitch_in_pci:
+            print(f"                     NOTE: NVSwitch hardware detected in PCI bus but NVLink")
+            print(f"                     is NOT exposed to the container GPU slice — the host has")
+            print(f"                     NVSwitch ASICs but pods only see a subset of GPUs without")
+            print(f"                     NVLink connectivity between them")
+    elif nvlink_pods > 0:
+        print(f"  GPU interconnect:  mixed — {nvlink_pods} pod(s) NVLink, {pcie_pods} pod(s) PCIe only")
+
+    # Hop distance
+    any_hop_issue = any("excessive hops" in w for w in warnings)
+    if any_hop_issue:
+        print(f"  Hop distance:      sub-optimal — some GPU pairs traverse high-latency PCIe paths")
+        print(f"                     (SYS = cross-socket, PHB = cross PCIe root complex)")
+    else:
+        print(f"  Hop distance:      OK — no excessive hops between GPU pairs")
+    explain_cmd(f"{kx} nvidia-smi topo -m | grep -E 'SYS|PHB'",
+                "SYS = cross-socket hop (worst), PHB = cross PCIe root (bad); absence = good")
+
+    # NUMA affinity
+    any_numa_split = any("span" in w and "NUMA" in w for w in warnings)
+    if any_numa_split:
+        split_pods = sum(1 for t in all_pod_results.values()
+                         if len(set(t.get("gpu_numa", {}).values()) - {-1}) > 1)
+        print(f"  NUMA affinity:     SPLIT — {split_pods} pod(s) have GPUs on different NUMA nodes")
+        print(f"                     Cross-socket PCIe traffic adds latency and contention")
+        print(f"                     to collective ops (allreduce, allgather, send/recv)")
+    else:
+        all_numa = [set(t.get("gpu_numa", {}).values()) - {-1} for t in all_pod_results.values()
+                    if t.get("gpu_numa")]
+        if all_numa and all(len(ns) <= 1 for ns in all_numa):
+            print(f"  NUMA affinity:     OK — all GPUs on same NUMA node per pod")
+        elif not all_numa:
+            print(f"  NUMA affinity:     could not determine")
+        else:
+            print(f"  NUMA affinity:     OK")
+    explain_cmd(
+        f"{kx} bash -c \"nvidia-smi --query-gpu=index,gpu_bus_id --format=csv,noheader | "
+        f"while IFS=, read idx bus; do bus=$(echo $bus | tr -d ' ' | sed 's/^0\\{{4,\\}}/0000/'); "
+        f"echo GPU$idx: NUMA $(cat /sys/bus/pci/devices/$bus/numa_node 2>/dev/null); done\"",
+        "maps each GPU to its NUMA node via PCI bus ID; all same = OK, different = SPLIT")
+
+    # PCIe root spread
+    any_pcie_spread = any("PCIe root port" in w for w in warnings)
+    if any_pcie_spread:
+        spread_pods = sum(1 for t in all_pod_results.values()
+                          if len(set(info["root_port"] for info in t.get("gpu_pcie", {}).values()
+                                     if info.get("root_port") != "unknown")) > 1)
+        print(f"  PCIe root spread:  {spread_pods} pod(s) have GPUs under different PCIe root ports")
+        print(f"                     Cross-root P2P transfers route through CPU fabric, reducing bandwidth")
+    else:
+        all_roots = [set(info["root_port"] for info in t.get("gpu_pcie", {}).values()
+                         if info.get("root_port") != "unknown")
+                     for t in all_pod_results.values() if t.get("gpu_pcie")]
+        if all_roots and all(len(rs) <= 1 for rs in all_roots):
+            print(f"  PCIe root spread:  OK — all GPUs under same root port per pod")
+        elif not all_roots:
+            print(f"  PCIe root spread:  could not determine")
+        else:
+            print(f"  PCIe root spread:  OK")
+    explain_cmd(
+        f"{kx} bash -c \"nvidia-smi --query-gpu=index,gpu_bus_id --format=csv,noheader | "
+        f"while IFS=, read idx bus; do bus=$(echo $bus | tr -d ' ' | sed 's/^0\\{{4,\\}}/0000/'); "
+        f"chain=$(readlink -f /sys/bus/pci/devices/$bus | grep -oE '[0-9a-f]{{4}}:[0-9a-f]{{2}}:[0-9a-f]{{2}}\\.[0-9a-f]' | head -2); "
+        f"echo GPU$idx: root=$(echo $chain | awk '{{print $2}}'); done\"",
+        "shows PCI root port for each GPU; all same = OK, different = GPUs span root complexes")
+
+    # PCIe switch topology (PXB)
+    any_pxb = any("PXB" in w for w in warnings)
+    if any_pxb:
+        pxb_pods = sum(1 for t in all_pod_results.values()
+                       if len({sw for sw, gpus in t.get("pcie_switch_groups", {}).items()
+                               if sw != "unknown"}) > 1)
+        print(f"  PCIe switch topo:  {pxb_pods} pod(s) have GPUs under different PCIe switches")
+        print(f"                     PXB = cross-switch but same root complex — GPU pairs share")
+        print(f"                     a bottlenecked upstream link, reducing P2P bandwidth")
+    else:
+        all_switches = [
+            {sw for sw in t.get("pcie_switch_groups", {}) if sw != "unknown"}
+            for t in all_pod_results.values() if t.get("pcie_switch_groups")
+        ]
+        if all_switches and all(len(sws) <= 1 for sws in all_switches):
+            print(f"  PCIe switch topo:  OK — all GPUs behind same PCIe switch per pod")
+        elif not all_switches:
+            print(f"  PCIe switch topo:  could not determine")
+        else:
+            print(f"  PCIe switch topo:  OK — no PXB cross-switch connections detected")
+    explain_cmd(f"{kx} nvidia-smi topo -m | grep PXB",
+                "PXB in matrix = cross PCIe switch (shared upstream); absence = all behind same switch")
+    explain_cmd(
+        f"{kx} bash -c \"nvidia-smi --query-gpu=index,gpu_bus_id --format=csv,noheader | "
+        f"while IFS=, read idx bus; do bus=$(echo $bus | tr -d ' ' | sed 's/^0\\{{4,\\}}/0000/'); "
+        f"dev=$(readlink -f /sys/bus/pci/devices/$bus); parent=$(dirname $dev); "
+        f"sw=$(basename $parent); class=$(cat $parent/class 2>/dev/null); "
+        f"echo GPU$idx: switch=$sw class=$class; done\"",
+        "class 0x0604 = PCI bridge; same parent bridge = co-located, different = separate switches")
+
+    # NVSwitch domain
+    if any(v is True for v in all_has_nvlink):
+        if all(v is True for v in all_nvswitch_uniform if v is not None):
+            print(f"  NVSwitch domain:   uniform — all GPUs in same NVLink group per pod")
+        elif any(v is False for v in all_nvswitch_uniform):
+            print(f"  NVSwitch domain:   SPLIT — GPUs span different NVSwitch domains in some pods")
+        else:
+            print(f"  NVSwitch domain:   uniform — no split detected")
+    else:
+        print(f"  NVSwitch domain:   N/A — no NVLink connections active in pods")
+    explain_cmd(f"{kx} nvidia-smi topo -m",
+                "uniform = all NV## values identical between GPU pairs; different NV## values = split domains")
+
+    # NVLink status
+    total_active = sum(all_nvl_active)
+    total_inactive = sum(t.get("nvlink_inactive", 0) for t in all_pod_results.values())
+    if total_active > 0 or total_inactive > 0:
+        print(f"  NVLink status:     {total_active} active, {total_inactive} inactive across all pods")
+        if total_inactive > 0:
+            print(f"                     WARNING: inactive NVLink connections may indicate hardware issues")
+    else:
+        print(f"  NVLink status:     no active NVLink connections in any pod")
+    explain_cmd(f"{kx} nvidia-smi nvlink --status | grep -cE '(active|inactive)'",
+                "count active/inactive NVLink connections per GPU")
+
+    # NCCL config
+    nccl_envs = [t.get("nccl_env", {}) for t in all_pod_results.values()]
+    any_nccl_mismatch = any("MISMATCH:" in w and "differs across pods" in w for w in warnings)
+    ib_disabled_pods = sum(1 for e in nccl_envs if e.get("NCCL_IB_DISABLE") == "1")
+    hca_set_pods = sum(1 for e in nccl_envs if e.get("NCCL_IB_HCA"))
+    exclude_set_pods = sum(1 for e in nccl_envs if e.get("NCCL_EXCLUDE_IB_HCA"))
+    socket_set_pods = sum(1 for e in nccl_envs if e.get("NCCL_SOCKET_IFNAME"))
+
+    print(f"  NCCL config:")
+    explain_cmd(f"{kx} bash -c \"env | grep -E '^NCCL_' | sort\"",
+                "all NCCL environment variables controlling collective transport")
+    if ib_disabled_pods > 0:
+        print(f"    IB/RoCE:         DISABLED on {ib_disabled_pods}/{num_pods} pod(s) — RDMA will not be used")
+    else:
+        print(f"    IB/RoCE:         enabled (NCCL_IB_DISABLE not set or =0)")
+    if hca_set_pods > 0:
+        sample_hca = next((e["NCCL_IB_HCA"] for e in nccl_envs if e.get("NCCL_IB_HCA")), "")
+        print(f"    NCCL_IB_HCA:     set on {hca_set_pods}/{num_pods} pod(s) ({sample_hca})")
+    elif exclude_set_pods > 0:
+        sample_excl = next((e["NCCL_EXCLUDE_IB_HCA"] for e in nccl_envs if e.get("NCCL_EXCLUDE_IB_HCA")), "")
+        rdma_count = len(list(all_pod_results.values())[0].get("rdma_devices", []))
+        excl_count = len([x for x in sample_excl.split(",") if x.strip()])
+        active_count = rdma_count - excl_count
+        print(f"    Device filter:   NCCL_EXCLUDE_IB_HCA excludes {excl_count} of {rdma_count} RDMA devices "
+              f"({active_count} active)")
+    else:
+        rdma_count = len(list(all_pod_results.values())[0].get("rdma_devices", [])) if all_pod_results else 0
+        if rdma_count > 0:
+            print(f"    Device filter:   none — NCCL will use all {rdma_count} RDMA device(s)")
+        else:
+            print(f"    Device filter:   no RDMA devices found")
+    if socket_set_pods > 0:
+        sample_sock = next((e["NCCL_SOCKET_IFNAME"] for e in nccl_envs if e.get("NCCL_SOCKET_IFNAME")), "")
+        print(f"    Socket iface:    {sample_sock} on {socket_set_pods}/{num_pods} pod(s)")
+    else:
+        print(f"    Socket iface:    auto-select (NCCL_SOCKET_IFNAME not set)")
+    if any_nccl_mismatch:
+        print(f"    Consistency:     MISMATCH — env vars differ across pods (see warnings above)")
+    else:
+        print(f"    Consistency:     OK — env vars match across all pods")
+
+    # UCX config summary
+    ucx_tls_pods = sum(1 for e in nccl_envs if e.get("UCX_TLS"))
+    ucx_net_pods = sum(1 for e in nccl_envs if e.get("UCX_NET_DEVICES"))
+    ucx_any_pods = sum(1 for e in nccl_envs if any(k.startswith("UCX_") for k in e))
+    nccl_net_ucx = sum(1 for e in nccl_envs if (e.get("NCCL_NET") or "").lower() == "ucx")
+
+    if ucx_any_pods > 0 or nccl_net_ucx > 0:
+        print(f"  UCX config:")
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^UCX_' | sort\"",
+                    "all UCX environment variables controlling transport selection and RDMA behavior")
+        if nccl_net_ucx > 0:
+            print(f"    NCCL transport:  UCX plugin (NCCL_NET=UCX on {nccl_net_ucx}/{num_pods} pod(s))")
+        if ucx_tls_pods > 0:
+            sample_tls = next((e["UCX_TLS"] for e in nccl_envs if e.get("UCX_TLS")), "")
+            print(f"    UCX_TLS:         {sample_tls}")
+            tls_list = [t.strip().lower() for t in sample_tls.split(",")]
+            rdma_tls = {"rc", "rc_v", "rc_x", "ud", "ud_v", "ud_x", "dc", "dc_x"}
+            gpu_tls = {"cuda_copy", "cuda_ipc", "gdr_copy"}
+            active_rdma = sorted(set(tls_list) & rdma_tls)
+            active_gpu = sorted(set(tls_list) & gpu_tls)
+            if active_rdma:
+                print(f"                     RDMA transports: {', '.join(active_rdma)}")
+            if active_gpu:
+                print(f"                     GPU transports: {', '.join(active_gpu)}")
+            if "tcp" in tls_list:
+                print(f"                     WARNING: tcp fallback enabled — slow for GPU workloads")
+        else:
+            print(f"    UCX_TLS:         not set (UCX auto-selects)")
+        if ucx_net_pods > 0:
+            sample_net = next((e["UCX_NET_DEVICES"] for e in nccl_envs if e.get("UCX_NET_DEVICES")), "")
+            print(f"    UCX_NET_DEVICES: {sample_net}")
+        else:
+            print(f"    UCX_NET_DEVICES: not set (UCX auto-selects RDMA devices)")
+        # Show other notable UCX vars
+        for var_name, desc in [
+            ("UCX_MAX_RNDV_RAILS", "multi-rail parallelism"),
+            ("UCX_RNDV_THRESH", "rendezvous threshold"),
+            ("UCX_MEMTYPE_CACHE", "GPU memory type cache"),
+        ]:
+            val_pods = sum(1 for e in nccl_envs if e.get(var_name))
+            if val_pods > 0:
+                sample_val = next((e[var_name] for e in nccl_envs if e.get(var_name)), "")
+                print(f"    {var_name}: {sample_val} ({desc})")
+
+    # vLLM / CUDA / NIXL config summary
+    vllm_pods = sum(1 for e in nccl_envs if any(k.startswith("VLLM_") for k in e))
+    cuda_pods = sum(1 for e in nccl_envs if any(k.startswith("CUDA_") for k in e))
+    nixl_pods = sum(1 for e in nccl_envs if any(k.startswith("NIXL_") for k in e))
+
+    if vllm_pods > 0 or cuda_pods > 0 or nixl_pods > 0:
+        print(f"\n  Inference runtime config:")
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^(VLLM_|CUDA_|TORCH_|NIXL_|MASTER_|RANK=|WORLD_SIZE=|LOCAL_RANK=)' | sort\"",
+                    "all vLLM, CUDA, PyTorch distributed, and NIXL environment variables")
+
+        # CUDA config
+        if cuda_pods > 0:
+            sample_cuda_order = next((e.get("CUDA_DEVICE_ORDER") for e in nccl_envs
+                                      if e.get("CUDA_DEVICE_ORDER")), None)
+            sample_cuda_module = next((e.get("CUDA_MODULE_LOADING") for e in nccl_envs
+                                       if e.get("CUDA_MODULE_LOADING")), None)
+            sample_cuda_visible = next((e.get("CUDA_VISIBLE_DEVICES") for e in nccl_envs
+                                        if e.get("CUDA_VISIBLE_DEVICES")), None)
+            if sample_cuda_visible:
+                print(f"    CUDA_VISIBLE_DEVICES: {sample_cuda_visible}")
+            if sample_cuda_order:
+                print(f"    CUDA_DEVICE_ORDER: {sample_cuda_order}")
+            elif any(t.get("gpu_count", 0) > 1 for t in all_pod_results.values()):
+                print(f"    CUDA_DEVICE_ORDER: not set (recommend PCI_BUS_ID for stable ordering)")
+            if sample_cuda_module:
+                print(f"    CUDA_MODULE_LOADING: {sample_cuda_module}")
+            else:
+                print(f"    CUDA_MODULE_LOADING: not set (defaults to EAGER; LAZY reduces memory)")
+
+            # Check for debugging vars in production
+            any_blocking = any(e.get("CUDA_LAUNCH_BLOCKING") == "1" for e in nccl_envs)
+            if any_blocking:
+                print(f"    WARNING: CUDA_LAUNCH_BLOCKING=1 on some pods — severe perf penalty")
+
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^CUDA_'\"",
+                    "CUDA environment: device visibility, ordering, module loading mode")
+
+        # vLLM config
+        if vllm_pods > 0:
+            sample_vllm = next((e for e in nccl_envs if any(k.startswith("VLLM_") for k in e)), {})
+            dp_size = sample_vllm.get("VLLM_DP_SIZE")
+            host_ip = sample_vllm.get("VLLM_HOST_IP")
+            target_dev = sample_vllm.get("VLLM_TARGET_DEVICE")
+            disable_pynccl = sample_vllm.get("VLLM_DISABLE_PYNCCL")
+
+            if host_ip:
+                print(f"    VLLM_HOST_IP:    {host_ip}")
+            if dp_size:
+                print(f"    VLLM_DP_SIZE:    {dp_size}")
+            if target_dev:
+                print(f"    VLLM_TARGET_DEVICE: {target_dev}")
+            if disable_pynccl == "1":
+                print(f"    WARNING: VLLM_DISABLE_PYNCCL=1 — PyNCCL disabled, slower fallback")
+
+            # Show other notable vLLM vars
+            for var_name, desc in [
+                ("VLLM_CPU_KVCACHE_SPACE", "CPU KV cache offload (GiB)"),
+                ("VLLM_ENGINE_ITERATION_TIMEOUT_S", "engine iteration timeout"),
+                ("VLLM_USE_NCCL_SYMM_MEM", "NCCL symmetric memory"),
+                ("VLLM_NCCL_SO_PATH", "custom NCCL library path"),
+                ("VLLM_WORKER_MULTIPROC_METHOD", "worker process method"),
+                ("VLLM_FLOAT32_MATMUL_PRECISION", "matmul precision"),
+            ]:
+                val = sample_vllm.get(var_name)
+                if val:
+                    print(f"    {var_name}: {val} ({desc})")
+
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^VLLM_'\"",
+                    "vLLM inference engine configuration variables")
+
+        # NIXL / llm-d disaggregated KV transfer
+        if nixl_pods > 0:
+            sample_nixl = next((e for e in nccl_envs if any(k.startswith("NIXL_") for k in e)), {})
+            nixl_etcd = sample_nixl.get("NIXL_ETCD_ENDPOINTS")
+            nixl_ns = sample_nixl.get("NIXL_ETCD_NAMESPACE")
+            print(f"    llm-d / NIXL:    configured on {nixl_pods}/{num_pods} pod(s)")
+            if nixl_etcd:
+                print(f"    NIXL_ETCD_ENDPOINTS: {nixl_etcd}")
+            if nixl_ns:
+                print(f"    NIXL_ETCD_NAMESPACE: {nixl_ns}")
+            # Check if RDMA is available for KV transfer
+            sample_rdma = sample.get("rdma_devices", [])
+            if not sample_rdma:
+                print(f"    WARNING: NIXL configured but no RDMA devices — KV transfer will use TCP")
+            else:
+                print(f"    KV transfer:     RDMA available ({len(sample_rdma)} device(s))")
+
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^NIXL_'\"",
+                    "NIXL agent discovery and KV cache transfer configuration for llm-d")
+
+        # NCCL tuning for inference
+        any_p2p_disable = any(e.get("NCCL_P2P_DISABLE") == "1" for e in nccl_envs)
+        any_shm_disable = any(e.get("NCCL_SHM_DISABLE") == "1" for e in nccl_envs)
+        sample_max_ctas = next((e.get("NCCL_MAX_CTAS") for e in nccl_envs
+                                if e.get("NCCL_MAX_CTAS")), None)
+        if any_p2p_disable:
+            print(f"    WARNING: NCCL_P2P_DISABLE=1 on some pods — GPU P2P transfers disabled")
+        if any_shm_disable:
+            print(f"    WARNING: NCCL_SHM_DISABLE=1 on some pods — shared memory transport disabled")
+        if sample_max_ctas:
+            print(f"    NCCL_MAX_CTAS:   {sample_max_ctas} (limits GPU contention from NCCL kernels)")
+
+        # PyTorch distributed
+        master_set = sum(1 for e in nccl_envs if e.get("MASTER_ADDR"))
+        if master_set > 0:
+            sample_master = next((e.get("MASTER_ADDR") for e in nccl_envs if e.get("MASTER_ADDR")), "")
+            sample_world = next((e.get("WORLD_SIZE") for e in nccl_envs if e.get("WORLD_SIZE")), "?")
+            print(f"    PyTorch distributed: MASTER_ADDR={sample_master}, WORLD_SIZE={sample_world}")
+        explain_cmd(f"{kx} bash -c \"env | grep -E '^(MASTER_|WORLD_SIZE|RANK=|LOCAL_RANK=)'\"",
+                    "PyTorch distributed coordination: master address, world size, rank")
+
+    # Print verification summary if -x was used
+    if _get_common().EXPLAIN_VERIFY:
+        _print_verify_summary()
+
+    print()
+    return all_pod_results
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point — allows:  uv run run-tests-discovery.py [options]
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    _USAGE = """\
+Usage: uv run run-tests-discovery.py [options]
+
+Run GPU topology discovery on Kubernetes inference pods.
+
+Equivalent to: run-tests.sh -d
+
+Options:
+  -D, --debug-image IMAGE
+                        Use ephemeral debug containers with the given image.
+  -e, --explain         Show the kubectl/shell commands behind each finding.
+  -h, --help            Show this help message.
+  -i, --install-deps    Install missing tools (ibstat, ibv_devices) if needed.
+  -l, --label SELECTOR  Label selector to discover pods
+                        (default: "llm-d.ai/inferenceServing=true").
+  -n, --namespace NS    Kubernetes namespace for all kubectl commands.
+  -v, --verbose         Print kubectl commands as they run.
+  -x, --explain-verify  Run each explain command and verify output.
+                        Implies --explain.
+"""
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print(_USAGE)
+        sys.exit(0)
+
+    _c = _get_common()
+    _cfg = _c._parse_common_args()
+    _cfg["DISCOVER_ONLY"] = True
+    _c.configure(**_cfg)
+
+    _pods, _display_names = _c._discover_and_display()
+    if _c.USE_DEBUG_CONTAINER:
+        print("\nCreating debug containers ...")
+        _c.create_debug_containers(_pods)
+
+    run_topology_validation(_pods, _display_names)

--- a/run-tests-iperf3.py
+++ b/run-tests-iperf3.py
@@ -1,0 +1,280 @@
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""iperf3 network test runner for Kubernetes inference pods.
+
+Extracted from run-tests.py — runs iperf3 TCP bandwidth and UDP
+jitter/loss tests between all pod pairs.
+
+Public API:
+    run_iperf3(pods, display_names) -> dict
+"""
+
+import json
+import subprocess
+import threading
+import time
+
+from importlib import import_module
+
+# Import shared utilities from the common module.
+_common = None
+
+
+def _get_common():
+    global _common
+    if _common is None:
+        _common = import_module("run-tests-common")
+    return _common
+
+
+# Delegated to run-tests-common
+def exec_in_pod(*args, **kwargs):
+    return _get_common().exec_in_pod(*args, **kwargs)
+
+
+def _kubectl_ns_args():
+    return _get_common()._kubectl_ns_args()
+
+
+# ---------------------------------------------------------------------------
+# iperf3 functions
+# ---------------------------------------------------------------------------
+def start_iperf3_servers(pods):
+    for name, _ip in pods:
+        cmd = _get_common()._build_remote_cmd(name, ["iperf3", "-s"])
+        if _get_common().VERBOSE:
+            print(f"  $ {' '.join(cmd)}", flush=True)
+        proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        _get_common()._server_procs_append(proc)
+    print(f"Started iperf3 servers on {len(pods)} pods, waiting 2s ...")
+    time.sleep(2)
+
+
+def run_iperf3_client(src_name, dst_ip, extra_args=None):
+    cmd_args = ["iperf3", "-c", dst_ip] + (extra_args or []) + ["-J"]
+    result = exec_in_pod(src_name, cmd_args, timeout=60)
+    if result.returncode != 0:
+        return None
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def parse_iperf3_bw_gbps(data):
+    """Extract bandwidth in Gbps from iperf3 TCP JSON output."""
+    if data is None:
+        return None
+    try:
+        return data["end"]["sum_sent"]["bits_per_second"] / 1e9
+    except (KeyError, TypeError):
+        return None
+
+
+def parse_iperf3_udp_jitter_ms(data):
+    """Extract jitter in ms from iperf3 UDP JSON output."""
+    if data is None:
+        return None
+    try:
+        return data["end"]["sum"]["jitter_ms"]
+    except (KeyError, TypeError):
+        return None
+
+
+def parse_iperf3_udp_loss_pct(data):
+    """Extract packet loss percentage from iperf3 UDP JSON output."""
+    if data is None:
+        return None
+    try:
+        return data["end"]["sum"]["lost_percent"]
+    except (KeyError, TypeError):
+        return None
+
+
+def run_iperf3(pods, display_names):
+    """Run iperf3 TCP bandwidth + UDP jitter/latency for all pairs.
+
+    Non-interfering pairs (no shared source or destination pod) run in
+    parallel within the same wave, using one thread per pair.
+
+    iperf3 uses its own default buffer sizes (128K TCP, 8K UDP) — the
+    --block-sizes / --latency-size options only apply to RDMA perftest.
+    """
+    _c = _get_common()
+    print(f"\n{'=' * 60}")
+    print("  IPERF3 BANDWIDTH & LATENCY")
+    print(f"{'=' * 60}")
+
+    n = len(pods)
+    bw_matrix = [[None] * n for _ in range(n)]
+    jitter_matrix = [[None] * n for _ in range(n)]
+    loss_matrix = [[None] * n for _ in range(n)]
+
+    print("\nStarting iperf3 servers on all pods ...")
+    start_iperf3_servers(pods)
+
+    test_pairs = _c._cross_role_pairs(pods)
+    waves = _c._schedule_parallel_pairs(n, pairs=test_pairs)
+    total_pairs = len(test_pairs)
+    done = 0
+
+    for wave_idx, wave in enumerate(waves):
+        pair_labels = ", ".join(
+            f"{display_names[pods[i][0]]}->{display_names[pods[j][0]]}"
+            for i, j in wave
+        )
+        print(f"\n  [wave {wave_idx + 1}/{len(waves)}] "
+              f"{len(wave)} pair(s) in parallel: {pair_labels}")
+
+        # Per-pair thread state
+        buffers = []
+        results_slot = [None] * len(wave)
+        done_events = [threading.Event() for _ in wave]
+
+        def _worker(slot, i, j, buf, done_evt):
+            try:
+                src_name = pods[i][0]
+                dst_ip = pods[j][1]
+                src_short = display_names[src_name]
+                dst_short = display_names[pods[j][0]]
+
+                def _out(msg):
+                    buf.write(msg + "\n")
+
+                _out(f"\n    {src_short} -> {dst_short}")
+
+                # TCP bandwidth test (5s, 1s interval)
+                try:
+                    tcp_data = run_iperf3_client(src_name, dst_ip, ["-t", "5", "-i", "1"])
+                    bw = parse_iperf3_bw_gbps(tcp_data)
+                except subprocess.TimeoutExpired:
+                    bw = None
+                if bw is not None:
+                    _out(f"    TCP bandwidth: {bw:.2f} Gbps")
+                else:
+                    _out(f"    TCP bandwidth: FAIL")
+
+                # UDP jitter/latency test (5s, 1s interval)
+                try:
+                    udp_data = run_iperf3_client(src_name, dst_ip, ["-u", "-t", "5", "-i", "1"])
+                    jitter = parse_iperf3_udp_jitter_ms(udp_data)
+                    loss = parse_iperf3_udp_loss_pct(udp_data)
+                except subprocess.TimeoutExpired:
+                    jitter = None
+                    loss = None
+
+                parts = []
+                if jitter is not None:
+                    parts.append(f"{jitter:.3f} ms jitter")
+                if loss is not None:
+                    parts.append(f"{loss:.2f}% loss")
+                if parts:
+                    _out(f"    UDP: {', '.join(parts)}")
+                else:
+                    _out(f"    UDP: FAIL")
+
+                results_slot[slot] = (i, j, bw, jitter, loss)
+            except Exception as exc:
+                buf.write(f"\n    ERROR: {exc}\n")
+                results_slot[slot] = (i, j, None, None, None)
+            finally:
+                done_evt.set()
+
+        # Launch threads for this wave
+        threads = []
+        for slot, (i, j) in enumerate(wave):
+            buf = _c._StreamingBuffer()
+            buffers.append(buf)
+            t = threading.Thread(
+                target=_worker,
+                args=(slot, i, j, buf, done_events[slot]),
+                daemon=True,
+            )
+            threads.append(t)
+            t.start()
+
+        # Wait and flush output in pair order
+        for slot in range(len(wave)):
+            done_events[slot].wait()
+            buffers[slot].flush_all()
+
+        for t in threads:
+            t.join(timeout=5)
+
+        # Store results in matrices
+        for slot in range(len(wave)):
+            if results_slot[slot] is not None:
+                i, j, bw, jitter, loss = results_slot[slot]
+                bw_matrix[i][j] = bw
+                jitter_matrix[i][j] = jitter
+                loss_matrix[i][j] = loss
+                done += 1
+
+    print(f"\n  Completed {done}/{total_pairs} pair(s)")
+    print("\nStopping iperf3 servers ...")
+    _c._cleanup_servers()
+
+    return {
+        "iperf3 Bandwidth (Gbps)": bw_matrix,
+        "iperf3 UDP Jitter (ms)": jitter_matrix,
+        "iperf3 UDP Loss (%)": loss_matrix,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point — allows:  uv run run-tests-iperf3.py [options]
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    import sys as _sys
+
+    _USAGE = """\
+Usage: uv run run-tests-iperf3.py [options]
+
+Run iperf3 TCP bandwidth and UDP jitter/loss tests between Kubernetes
+inference pods.
+
+Equivalent to: run-tests.sh -t iperf3
+
+Options:
+  -D, --debug-image IMAGE
+                        Use ephemeral debug containers with the given image.
+  -e, --explain         Show the kubectl/shell commands behind each finding.
+  -h, --help            Show this help message.
+  -i, --install-deps    Install iperf3 if missing.
+  -l, --label SELECTOR  Label selector to discover pods
+                        (default: "llm-d.ai/inferenceServing=true").
+  -n, --namespace NS    Kubernetes namespace for all kubectl commands.
+  -p, --percentage-margin PCT
+                        Flag results deviating more than PCT% from average
+                        (default: 10).
+  -v, --verbose         Print kubectl commands as they run.
+  -x, --explain-verify  Run each explain command and verify output.
+                        Implies --explain.
+"""
+    if "-h" in _sys.argv or "--help" in _sys.argv:
+        print(_USAGE)
+        _sys.exit(0)
+
+    _c = _get_common()
+    _cfg = _c._parse_common_args()
+    _c.configure(**_cfg)
+
+    _pods, _display_names = _c._discover_and_display()
+    if _c.USE_DEBUG_CONTAINER:
+        print("\nCreating debug containers ...")
+        _c.create_debug_containers(_pods)
+
+    _results = run_iperf3(_pods, _display_names)
+    for _title, _matrix in _results.items():
+        print(f"\n{_title}:")
+        _header = [""] + [_display_names[p[0]] for p in _pods]
+        print("  " + "\t".join(_header))
+        for _i, (_name, _ip) in enumerate(_pods):
+            _row = [_display_names[_name]]
+            for _j in range(len(_pods)):
+                _val = _matrix[_i][_j]
+                _row.append(f"{_val:.2f}" if _val is not None else "-")
+            print("  " + "\t".join(_row))
+    _c.print_results_summary(_pods, _results, _display_names)
+

--- a/run-tests-nccl-rccl.py
+++ b/run-tests-nccl-rccl.py
@@ -1,0 +1,1159 @@
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""NCCL/RCCL collective operation test runner for Kubernetes inference pods.
+
+Detects GPU vendor per pod (NVIDIA vs AMD), builds nccl-tests or rccl-tests
+from source if needed, sets up passwordless SSH for mpirun, runs
+all_reduce_perf across same-vendor pods, and displays results.
+
+Public API:
+    run_nccl_rccl(pods, display_names) -> dict
+"""
+
+import subprocess
+import sys
+import threading
+
+from importlib import import_module
+
+# Import shared utilities from the common module.
+_common = None
+_discovery = None
+
+
+def _get_common():
+    global _common
+    if _common is None:
+        _common = import_module("run-tests-common")
+    return _common
+
+
+def _get_discovery():
+    global _discovery
+    if _discovery is None:
+        _discovery = import_module("run-tests-discovery")
+    return _discovery
+
+
+# Delegated to run-tests-common
+def exec_in_pod(*args, **kwargs):
+    return _get_common().exec_in_pod(*args, **kwargs)
+
+
+def _kubectl_ns_args():
+    return _get_common()._kubectl_ns_args()
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+NCCL_TESTS_REPO = "https://github.com/NVIDIA/nccl-tests.git"
+RCCL_TESTS_REPO = "https://github.com/ROCm/rccl-tests.git"
+NCCL_TESTS_DIR = "/tmp/nccl-tests"
+RCCL_TESTS_DIR = "/tmp/rccl-tests"
+NCCL_BINARY = "/tmp/nccl-tests/build/all_reduce_perf"
+RCCL_BINARY = "/tmp/rccl-tests/build/all_reduce_perf"
+
+OPENMPI_VERSION = "4.1.6"
+OPENMPI_URL = (f"https://download.open-mpi.org/release/open-mpi/v4.1/"
+               f"openmpi-{OPENMPI_VERSION}.tar.gz")
+OPENMPI_BUILD_DIR = "/tmp/openmpi-build"
+
+# Default all_reduce_perf arguments
+AR_MIN_BYTES = "8"
+AR_MAX_BYTES = "128M"
+AR_FACTOR = "2"
+AR_GPUS_PER_PROC = "1"
+
+# SSH port for sshd in pods
+SSHD_PORT = 22
+
+
+# ---------------------------------------------------------------------------
+# GPU vendor detection (reuses run-tests-discovery.py)
+# ---------------------------------------------------------------------------
+def detect_gpu_vendor(pod_name):
+    """Detect GPU vendor on a pod: 'nvidia', 'amd', or 'unknown'."""
+    return _get_discovery()._detect_gpu_vendor(pod_name)
+
+
+def detect_all_gpu_vendors(pods):
+    """Detect GPU vendor for all pods in parallel.
+
+    Returns dict: {pod_name: 'nvidia'|'amd'|'unknown'}
+    """
+    _c = _get_common()
+    vendors = {}
+    lock = threading.Lock()
+    bufs = [_c._StreamingBuffer() for _ in range(len(pods))]
+    done_events = [threading.Event() for _ in range(len(pods))]
+
+    def _worker(idx, pod_name, buf, done_evt):
+        try:
+            v = detect_gpu_vendor(pod_name)
+            buf.write(f"  {pod_name}: {v} GPU\n")
+            with lock:
+                vendors[pod_name] = v
+        except Exception as exc:
+            buf.write(f"  {pod_name}: ERROR detecting GPU vendor: {exc}\n")
+            with lock:
+                vendors[pod_name] = "unknown"
+        finally:
+            done_evt.set()
+
+    threads = []
+    for idx, (name, _ip) in enumerate(pods):
+        t = threading.Thread(
+            target=_worker,
+            args=(idx, name, bufs[idx], done_events[idx]),
+            daemon=True,
+        )
+        threads.append(t)
+        t.start()
+
+    for idx in range(len(pods)):
+        while not done_events[idx].is_set():
+            bufs[idx].flush_new()
+            done_events[idx].wait(timeout=0.1)
+        bufs[idx].flush_all()
+
+    for t in threads:
+        t.join(timeout=5)
+
+    return vendors
+
+
+# ---------------------------------------------------------------------------
+# GPU count detection
+# ---------------------------------------------------------------------------
+def detect_gpu_count(pod_name, vendor):
+    """Detect number of GPUs on a pod. Returns int or 0 on failure."""
+    if vendor == "nvidia":
+        result = exec_in_pod(pod_name, ["bash", "-c", "nvidia-smi -L 2>/dev/null | wc -l"],
+                             timeout=15, use_debug=False)
+    elif vendor == "amd":
+        result = exec_in_pod(pod_name, ["bash", "-c", "rocm-smi --showid 2>/dev/null | grep -c GPU || echo 0"],
+                             timeout=15, use_debug=False)
+    else:
+        return 0
+    if result.returncode == 0:
+        try:
+            return int(result.stdout.strip())
+        except ValueError:
+            pass
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Binary availability and build
+# ---------------------------------------------------------------------------
+def _tests_available(pod_name, binary_path):
+    """Check if all_reduce_perf binary exists at the given path."""
+    result = exec_in_pod(pod_name, ["test", "-x", binary_path], timeout=10, use_debug=False)
+    return result.returncode == 0
+
+
+def nccl_tests_available(pod_name):
+    return _tests_available(pod_name, NCCL_BINARY)
+
+
+def rccl_tests_available(pod_name):
+    return _tests_available(pod_name, RCCL_BINARY)
+
+
+def install_build_deps(pod_name, out=None):
+    """Install build dependencies for nccl/rccl-tests and OpenMPI.
+
+    Installs git, make, gcc, curl, then builds OpenMPI from source if
+    mpirun is not already available (RHEL UBI containers typically lack
+    openmpi packages in their repos).
+    """
+    _out = out or print
+    _out(f"  Installing build dependencies on {pod_name} ...")
+
+    # Step 1: Install basic build tools via package manager
+    rpm_pkgs = ["git", "make", "gcc", "gcc-c++", "curl", "bzip2"]
+    apt_pkgs = ["git", "make", "gcc", "g++", "curl", "bzip2"]
+
+    for pkg_mgr, install_cmd in [
+        ("dnf", ["dnf", "install", "-y"]),
+        ("yum", ["yum", "install", "-y"]),
+    ]:
+        check = exec_in_pod(pod_name, ["which", pkg_mgr], use_debug=False)
+        if check.returncode == 0:
+            result = exec_in_pod(pod_name, install_cmd + rpm_pkgs,
+                                 timeout=300, use_debug=False)
+            if result.returncode != 0:
+                _out(f"    Warning: failed to install build tools: "
+                     f"{result.stderr.strip()[:200]}")
+            else:
+                _out(f"    Installed build tools via {pkg_mgr}.")
+            # Also try installing openmpi package (works on Fedora, not UBI)
+            result = exec_in_pod(pod_name, install_cmd + ["openmpi", "openmpi-devel"],
+                                 timeout=120, use_debug=False)
+            if result.returncode == 0:
+                # Package install worked — symlink to standard PATH
+                exec_in_pod(pod_name, ["bash", "-c",
+                    "if [ -d /usr/lib64/openmpi/bin ] && ! command -v mpirun >/dev/null 2>&1; then "
+                    "  ln -sf /usr/lib64/openmpi/bin/* /usr/local/bin/ 2>/dev/null; "
+                    "  ln -sf /usr/lib64/openmpi/lib/* /usr/local/lib/ 2>/dev/null; "
+                    "  ldconfig 2>/dev/null; "
+                    "fi; true"
+                ], use_debug=False)
+            break
+    else:
+        exec_in_pod(pod_name, ["apt-get", "update"], timeout=60, use_debug=False)
+        result = exec_in_pod(pod_name, ["apt-get", "install", "-y"] + apt_pkgs,
+                             timeout=300, use_debug=False)
+        if result.returncode != 0:
+            _out(f"    Warning: failed to install build tools: "
+                 f"{result.stderr.strip()[:200]}")
+        else:
+            _out(f"    Installed build tools via apt.")
+        # Try package openmpi on Debian/Ubuntu
+        result = exec_in_pod(pod_name, ["apt-get", "install", "-y",
+                                         "openmpi-bin", "libopenmpi-dev"],
+                             timeout=120, use_debug=False)
+
+    # Step 2: If mpirun still not available, build OpenMPI from source
+    mpirun = find_mpirun(pod_name)
+    if mpirun:
+        _out(f"    mpirun already available: {mpirun}")
+        return True
+
+    _out(f"    OpenMPI not found in packages — building v{OPENMPI_VERSION} from source ...")
+    build_script = (
+        f"rm -rf {OPENMPI_BUILD_DIR} && mkdir -p {OPENMPI_BUILD_DIR} && "
+        f"cd {OPENMPI_BUILD_DIR} && "
+        f"curl -sL {OPENMPI_URL} | tar xz && "
+        f"cd openmpi-{OPENMPI_VERSION} && "
+        f"./configure --prefix=/usr/local --disable-man-pages "
+        f"  --with-cuda=/usr/local/cuda 2>&1 | tail -3 && "
+        f"make -j$(nproc) 2>&1 | tail -3 && "
+        f"make install 2>&1 | tail -3 && "
+        f"ldconfig"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", build_script],
+                         timeout=600, use_debug=False)
+    if result.returncode != 0:
+        _out(f"    OpenMPI build failed: {result.stderr.strip()[:500]}")
+        return False
+
+    mpirun = find_mpirun(pod_name)
+    if mpirun:
+        _out(f"    OpenMPI built successfully: {mpirun}")
+        return True
+
+    _out(f"    Warning: OpenMPI build completed but mpirun not found.")
+    return False
+
+
+def _find_nccl_paths(pod_name):
+    """Find NCCL include and lib paths on a pod.
+
+    Prefers the pip nvidia-nccl package over the system NCCL, because
+    the system NCCL at /lib64/ may have been compiled for a newer CUDA
+    than the installed driver supports (e.g. NCCL 2.29.7+cuda13.2 on a
+    CUDA 12.9 driver).  The pip package is typically matched to the
+    container's CUDA toolkit.
+
+    Returns (nccl_inc, nccl_lib) or (None, None).
+    """
+    result = exec_in_pod(pod_name, ["bash", "-c",
+        # 1. Prefer pip nvidia-nccl package (matched to container CUDA)
+        'PIP_INC=$(find /opt -path "*/nvidia/nccl/include/nccl.h" -type f 2>/dev/null | head -1); '
+        'PIP_LIB=$(find /opt -path "*/nvidia/nccl/lib/libnccl.so*" -type f 2>/dev/null | head -1); '
+        'if [ -n "$PIP_INC" ] && [ -n "$PIP_LIB" ]; then '
+        '  echo "INC=$(dirname $PIP_INC)"; '
+        '  echo "LIB=$(dirname $PIP_LIB)"; '
+        '  exit 0; '
+        'fi; '
+        # 2. Standard CUDA paths
+        'if [ -f /usr/local/cuda/include/nccl.h ]; then '
+        '  echo "INC=/usr/local/cuda/include"; '
+        '  echo "LIB=/usr/local/cuda/lib64"; '
+        'elif [ -f /usr/include/nccl.h ]; then '
+        '  echo "INC=/usr/include"; '
+        '  echo "LIB=/usr/lib64"; '
+        'else '
+        '  if [ -n "$PIP_INC" ]; then echo "INC=$(dirname $PIP_INC)"; fi; '
+        '  if [ -f /usr/lib64/libnccl.so ]; then '
+        '    echo "LIB=/usr/lib64"; '
+        '  elif [ -n "$PIP_LIB" ]; then '
+        '    echo "LIB=$(dirname $PIP_LIB)"; '
+        '  fi; '
+        'fi'
+    ], timeout=15, use_debug=False)
+
+    nccl_inc = nccl_lib = None
+    for line in (result.stdout or "").strip().split("\n"):
+        if line.startswith("INC="):
+            nccl_inc = line[4:]
+        elif line.startswith("LIB="):
+            nccl_lib = line[4:]
+    return nccl_inc, nccl_lib
+
+
+def build_nccl_tests(pod_name, out=None):
+    """Clone and build nccl-tests from source. Returns True on success."""
+    _out = out or print
+
+    # Find NCCL headers and libs
+    nccl_inc, nccl_lib = _find_nccl_paths(pod_name)
+    if not nccl_inc or not nccl_lib:
+        _out(f"  Error: NCCL headers/libs not found on {pod_name} "
+             f"(inc={nccl_inc}, lib={nccl_lib}).")
+        return False
+    _out(f"  NCCL paths: inc={nccl_inc}, lib={nccl_lib}")
+
+    _out(f"  Cloning nccl-tests on {pod_name} ...")
+    exec_in_pod(pod_name, ["rm", "-rf", NCCL_TESTS_DIR], use_debug=False)
+    result = exec_in_pod(pod_name, ["git", "clone", NCCL_TESTS_REPO, NCCL_TESTS_DIR],
+                         timeout=120, use_debug=False)
+    if result.returncode != 0:
+        _out(f"  Error cloning nccl-tests: {result.stderr.strip()[:300]}")
+        return False
+
+    # Verify clone produced a Makefile
+    check = exec_in_pod(pod_name, ["test", "-f", f"{NCCL_TESTS_DIR}/Makefile"],
+                        timeout=10, use_debug=False)
+    if check.returncode != 0:
+        _out(f"  Error: clone succeeded but {NCCL_TESTS_DIR}/Makefile not found.")
+        return False
+
+    _out(f"  Building nccl-tests on {pod_name} (make MPI=1) ...")
+    build_cmd = (
+        f"cd {NCCL_TESTS_DIR} && "
+        f"make MPI=1 MPI_HOME=/usr/local CUDA_HOME=/usr/local/cuda "
+        f"NCCL_INC={nccl_inc} NCCL_LIB={nccl_lib} -j$(nproc)"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", build_cmd], timeout=300, use_debug=False)
+    if _get_common().VERBOSE and result.stdout.strip():
+        _out(result.stdout[-500:])
+    if result.returncode != 0:
+        _out(f"  Build failed: {result.stderr.strip()[:500]}")
+        return False
+    _out(f"  nccl-tests built successfully on {pod_name}.")
+    return True
+
+
+def build_rccl_tests(pod_name, out=None):
+    """Clone and build rccl-tests from source. Returns True on success."""
+    _out = out or print
+    _out(f"  Cloning rccl-tests on {pod_name} ...")
+    exec_in_pod(pod_name, ["rm", "-rf", RCCL_TESTS_DIR], use_debug=False)
+    result = exec_in_pod(pod_name, ["git", "clone", RCCL_TESTS_REPO, RCCL_TESTS_DIR],
+                         timeout=120, use_debug=False)
+    if result.returncode != 0:
+        _out(f"  Error cloning rccl-tests: {result.stderr.strip()[:300]}")
+        return False
+
+    _out(f"  Building rccl-tests on {pod_name} (make MPI=1) ...")
+    build_cmd = (
+        f"cd {RCCL_TESTS_DIR} && "
+        f"make MPI=1 HIP_HOME=/opt/rocm RCCL_HOME=/opt/rocm -j$(nproc)"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", build_cmd], timeout=300, use_debug=False)
+    if _get_common().VERBOSE and result.stdout.strip():
+        _out(result.stdout[-500:])
+    if result.returncode != 0:
+        _out(f"  Build failed: {result.stderr.strip()[:500]}")
+        return False
+    _out(f"  rccl-tests built successfully on {pod_name}.")
+    return True
+
+
+def ensure_collective_tests(pod_name, vendor, out=None):
+    """Ensure all_reduce_perf is available, building if needed."""
+    _out = out or print
+    if vendor == "nvidia":
+        if nccl_tests_available(pod_name):
+            _out(f"  nccl-tests already available on {pod_name}.")
+            return True
+        if not _get_common().INSTALL_DEPS:
+            _out(f"  Error: nccl-tests not found on {pod_name}. Re-run with --install-deps.")
+            return False
+        _out(f"  nccl-tests not found on {pod_name}, building ...")
+        return build_nccl_tests(pod_name, out=_out)
+    elif vendor == "amd":
+        if rccl_tests_available(pod_name):
+            _out(f"  rccl-tests already available on {pod_name}.")
+            return True
+        if not _get_common().INSTALL_DEPS:
+            _out(f"  Error: rccl-tests not found on {pod_name}. Re-run with --install-deps.")
+            return False
+        _out(f"  rccl-tests not found on {pod_name}, building ...")
+        return build_rccl_tests(pod_name, out=_out)
+    else:
+        _out(f"  Skipping {pod_name}: unknown GPU vendor.")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# OpenSSH setup / teardown
+# ---------------------------------------------------------------------------
+def install_ssh(pod_name, out=None):
+    """Install SSH server and client on a pod.
+
+    Prefers dropbear (lightweight, no privsep/chroot needed in containers)
+    and falls back to openssh-server if dropbear is unavailable.
+    """
+    _out = out or print
+    _out(f"  Installing SSH on {pod_name} ...")
+
+    # Try rpm-based first, then apt
+    for pkg_mgr, install_cmd in [
+        ("dnf", ["dnf", "install", "-y"]),
+        ("yum", ["yum", "install", "-y"]),
+    ]:
+        check = exec_in_pod(pod_name, ["which", pkg_mgr], use_debug=False)
+        if check.returncode == 0:
+            # Prefer dropbear (works in containers without SYS_CHROOT)
+            result = exec_in_pod(pod_name, install_cmd + ["dropbear", "openssh-clients"],
+                                 timeout=120, use_debug=False)
+            if result.returncode == 0:
+                _out(f"    dropbear + ssh client installed via {pkg_mgr}.")
+                return True
+            # Fallback to openssh
+            result = exec_in_pod(pod_name, install_cmd + ["openssh-server", "openssh-clients"],
+                                 timeout=120, use_debug=False)
+            if result.returncode == 0:
+                _out(f"    openssh installed via {pkg_mgr}.")
+                return True
+            _out(f"    Warning: {pkg_mgr} install failed: {result.stderr.strip()[:200]}")
+            return False
+
+    # apt-based
+    exec_in_pod(pod_name, ["apt-get", "update"], timeout=60, use_debug=False)
+    result = exec_in_pod(pod_name, ["apt-get", "install", "-y", "dropbear", "openssh-client"],
+                         timeout=120, use_debug=False)
+    if result.returncode == 0:
+        _out(f"    dropbear + ssh client installed via apt.")
+        return True
+    result = exec_in_pod(pod_name, ["apt-get", "install", "-y",
+                                     "openssh-server", "openssh-client"],
+                         timeout=120, use_debug=False)
+    if result.returncode == 0:
+        _out(f"    openssh installed via apt.")
+        return True
+    _out(f"    Warning: apt install failed: {result.stderr.strip()[:200]}")
+    return False
+
+
+# Well-known locations where mpirun may be installed on RPM-based systems.
+_MPIRUN_SEARCH_PATHS = [
+    "/usr/lib64/openmpi/bin",
+    "/usr/lib/openmpi/bin",
+    "/usr/local/bin",
+    "/opt/amazon/openmpi/bin",
+    "/opt/hpcx/ompi/bin",
+]
+
+
+def find_mpirun(pod_name):
+    """Find the full path to mpirun on a pod.
+
+    Returns the path string, or None if not found.
+    """
+    # First try: mpirun on PATH
+    result = exec_in_pod(pod_name, ["bash", "-c", "command -v mpirun 2>/dev/null"],
+                         timeout=10, use_debug=False)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+
+    # Search well-known locations
+    search = " || ".join(
+        f'([ -x {p}/mpirun ] && echo {p}/mpirun)'
+        for p in _MPIRUN_SEARCH_PATHS
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", f"{search} || true"],
+                         timeout=10, use_debug=False)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip().split("\n")[0].strip()
+
+    return None
+
+
+def install_mpi(pod_name, out=None):
+    """Install OpenMPI on a pod. Returns path to mpirun or None."""
+    _out = out or print
+
+    # Check if already available
+    mpirun = find_mpirun(pod_name)
+    if mpirun:
+        _out(f"  mpirun already available on {pod_name}: {mpirun}")
+        return mpirun
+
+    if not _get_common().INSTALL_DEPS:
+        _out(f"  Error: mpirun not found on {pod_name}. Re-run with --install-deps.")
+        return None
+
+    _out(f"  Installing OpenMPI on {pod_name} ...")
+
+    for pkg_mgr, install_cmd, packages in [
+        ("dnf", ["dnf", "install", "-y"], ["openmpi", "openmpi-devel"]),
+        ("yum", ["yum", "install", "-y"], ["openmpi", "openmpi-devel"]),
+    ]:
+        check = exec_in_pod(pod_name, ["which", pkg_mgr], use_debug=False)
+        if check.returncode == 0:
+            result = exec_in_pod(pod_name, install_cmd + packages,
+                                 timeout=180, use_debug=False)
+            if result.returncode == 0:
+                _out(f"    OpenMPI installed via {pkg_mgr}.")
+            else:
+                _out(f"    Warning: {pkg_mgr} install failed: {result.stderr.strip()[:200]}")
+            # Even on failure, check if mpirun appeared
+            mpirun = find_mpirun(pod_name)
+            if mpirun:
+                _out(f"    mpirun found at: {mpirun}")
+                return mpirun
+            _out(f"    Warning: mpirun still not found after install.")
+            return None
+
+    # apt-based
+    exec_in_pod(pod_name, ["apt-get", "update"], timeout=60, use_debug=False)
+    result = exec_in_pod(pod_name, ["apt-get", "install", "-y",
+                                     "openmpi-bin", "libopenmpi-dev"],
+                         timeout=180, use_debug=False)
+    if result.returncode == 0:
+        _out(f"    OpenMPI installed via apt.")
+    else:
+        _out(f"    Warning: apt install failed: {result.stderr.strip()[:200]}")
+
+    mpirun = find_mpirun(pod_name)
+    if mpirun:
+        _out(f"    mpirun found at: {mpirun}")
+        return mpirun
+    _out(f"    Warning: mpirun still not found after install.")
+    return None
+
+
+def setup_ssh_cluster(group_pods, out=None):
+    """Set up passwordless SSH across a group of pods for mpirun.
+
+    - Generate a key pair on the first pod
+    - Distribute public key to all pods
+    - Start sshd on all pods
+    - Configure StrictHostKeyChecking=no
+
+    Returns True on success.
+    """
+    _out = out or print
+    if not group_pods:
+        return False
+
+    first_pod = group_pods[0][0]
+
+    # Install openssh on all pods in parallel
+    _c = _get_common()
+    n = len(group_pods)
+    bufs = [_c._StreamingBuffer() for _ in range(n)]
+    done_events = [threading.Event() for _ in range(n)]
+    install_ok = [False] * n
+
+    def _install_worker(idx, pod_name, buf, done_evt):
+        try:
+            install_ok[idx] = install_ssh(pod_name, out=lambda msg: buf.write(msg + "\n"))
+        except Exception as exc:
+            buf.write(f"  ERROR installing openssh on {pod_name}: {exc}\n")
+        finally:
+            done_evt.set()
+
+    threads = []
+    for idx, (name, _ip) in enumerate(group_pods):
+        t = threading.Thread(
+            target=_install_worker,
+            args=(idx, name, bufs[idx], done_events[idx]),
+            daemon=True,
+        )
+        threads.append(t)
+        t.start()
+
+    for idx in range(n):
+        while not done_events[idx].is_set():
+            bufs[idx].flush_new()
+            done_events[idx].wait(timeout=0.1)
+        bufs[idx].flush_all()
+
+    for t in threads:
+        t.join(timeout=5)
+
+    if not all(install_ok):
+        _out("  Warning: openssh installation failed on some pods.")
+
+    # Determine the actual HOME directory (may differ from /root in containers)
+    home_result = exec_in_pod(first_pod, ["bash", "-c", 'echo "$HOME"'],
+                              timeout=10, use_debug=False)
+    ssh_home = (home_result.stdout.strip() or "/root")
+    ssh_dir = f"{ssh_home}/.ssh"
+    key_path = f"{ssh_dir}/nccl_test_key"
+    _out(f"  Using SSH home: {ssh_home}")
+
+    # Generate SSH key on first pod
+    _out(f"\n  Generating SSH key pair on {first_pod} ...")
+    exec_in_pod(first_pod, ["bash", "-c",
+        f"mkdir -p {ssh_dir} && chmod 700 {ssh_dir} && "
+        f"rm -f {key_path} {key_path}.pub && "
+        f"ssh-keygen -t rsa -b 2048 -N '' -f {key_path} -q"
+    ], use_debug=False)
+
+    # Read the public key
+    result = exec_in_pod(first_pod, ["cat", f"{key_path}.pub"],
+                         timeout=10, use_debug=False)
+    if result.returncode != 0 or not result.stdout.strip():
+        _out(f"  Error: failed to generate SSH key at {key_path}.pub")
+        return False
+    pub_key = result.stdout.strip()
+
+    # Distribute public key and start sshd on all pods
+    for name, _ip in group_pods:
+        _out(f"  Setting up SSH on {name} ...")
+
+        # Create .ssh dir, add authorized key, configure ssh.
+        # We write authorized_keys to BOTH the container user's home AND
+        # /root/.ssh/, because dropbear/sshd look up the target user's home
+        # (we SSH as root, so it checks /root/.ssh/authorized_keys).
+        setup_script = (
+            f"mkdir -p {ssh_dir} && chmod 700 {ssh_dir} && "
+            f"echo '{pub_key}' >> {ssh_dir}/authorized_keys && "
+            f"chmod 600 {ssh_dir}/authorized_keys && "
+            f"echo 'StrictHostKeyChecking no' > {ssh_dir}/config && "
+            f"echo 'UserKnownHostsFile /dev/null' >> {ssh_dir}/config && "
+            f"chmod 600 {ssh_dir}/config && "
+            # Also set up /root/.ssh if HOME is not /root
+            f"if [ '{ssh_home}' != '/root' ]; then "
+            f"  mkdir -p /root/.ssh && chmod 700 /root/.ssh && "
+            f"  echo '{pub_key}' >> /root/.ssh/authorized_keys && "
+            f"  chmod 600 /root/.ssh/authorized_keys && "
+            f"  cp {ssh_dir}/config /root/.ssh/config && "
+            f"  chmod 600 /root/.ssh/config; "
+            f"fi && "
+            f"mkdir -p /etc/ssh"
+        )
+        exec_in_pod(name, ["bash", "-c", setup_script], use_debug=False)
+
+        # Unlock root account (needed for dropbear and some sshd configs)
+        exec_in_pod(name, ["bash", "-c", "passwd -u root 2>/dev/null; true"],
+                    use_debug=False)
+
+        # Kill any existing SSH server first
+        exec_in_pod(name, ["bash", "-c",
+            "pkill dropbear 2>/dev/null; pkill sshd 2>/dev/null; sleep 0.3; true"
+        ], timeout=10, use_debug=False)
+
+        # Start SSH server: prefer dropbear (no privsep/chroot needed)
+        # dropbear forks to background by default (no -F), don't use -E
+        # (logging to stderr keeps kubectl exec open)
+        result = exec_in_pod(name, ["bash", "-c",
+            "if command -v dropbear >/dev/null 2>&1; then "
+            "  mkdir -p /etc/dropbear && "
+            "  dropbear -R -p 22 2>/dev/null && sleep 0.3 && "
+            "  pgrep -x dropbear >/dev/null && echo SSHD_OK || echo SSHD_FAIL; "
+            "else "
+            "  mkdir -p /run/sshd && "
+            "  [ -f /etc/ssh/ssh_host_rsa_key ] || ssh-keygen -A 2>/dev/null; "
+            "  (/usr/sbin/sshd -o PermitRootLogin=yes -o UsePrivilegeSeparation=no "
+            f"   -o AuthorizedKeysFile={ssh_dir}/authorized_keys 2>/dev/null || "
+            "   sshd -o PermitRootLogin=yes 2>/dev/null) "
+            "  && echo SSHD_OK || echo SSHD_FAIL; "
+            "fi"
+        ], timeout=30, use_debug=False)
+        if "SSHD_OK" in (result.stdout or ""):
+            _out(f"    SSH server started on {name}.")
+        else:
+            _out(f"    Warning: SSH server may not have started on {name}: "
+                 f"{result.stderr.strip()[:200]}")
+
+    # Copy private key as id_rsa for mpirun convenience (both user home and /root)
+    exec_in_pod(first_pod, ["bash", "-c",
+        f"cp {key_path} {ssh_dir}/id_rsa && chmod 600 {ssh_dir}/id_rsa && "
+        f"if [ '{ssh_home}' != '/root' ]; then "
+        f"  cp {key_path} /root/.ssh/id_rsa && chmod 600 /root/.ssh/id_rsa && "
+        f"  cp {key_path} /root/.ssh/nccl_test_key && chmod 600 /root/.ssh/nccl_test_key; "
+        f"fi"
+    ], use_debug=False)
+
+    # Verify SSH connectivity from first pod to all others
+    _out("\n  Verifying SSH connectivity ...")
+    all_ok = True
+    for name, ip in group_pods:
+        result = exec_in_pod(first_pod, ["bash", "-c",
+            f"ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null "
+            f"-o ConnectTimeout=5 -i {key_path} root@{ip} echo ok"
+        ], timeout=15, use_debug=False)
+        if result.returncode == 0:
+            _out(f"    {first_pod} -> {name} ({ip}): OK")
+        else:
+            _out(f"    {first_pod} -> {name} ({ip}): FAILED — "
+                 f"{result.stderr.strip()[:200]}")
+            all_ok = False
+
+    # Return both ok status and key_path for use in mpirun
+    return all_ok, key_path
+
+
+def stop_sshd_all(pods, ssh_dir=None, out=None):
+    """Stop SSH server (dropbear or sshd) on all pods and clean up keys."""
+    _out = out or print
+    _out("\n  Stopping SSH servers on all pods ...")
+    clean_dir = ssh_dir or "$HOME/.ssh"
+    for name, _ip in pods:
+        exec_in_pod(name, ["bash", "-c",
+            "pkill dropbear 2>/dev/null; pkill sshd 2>/dev/null; "
+            f"rm -f {clean_dir}/nccl_test_key {clean_dir}/nccl_test_key.pub "
+            f"{clean_dir}/id_rsa "
+            f"/root/.ssh/nccl_test_key /root/.ssh/id_rsa "
+            f"/root/.ssh/authorized_keys /root/.ssh/config; true"
+        ], timeout=10, use_debug=False)
+    _out("  SSH servers stopped and keys cleaned up.")
+
+
+# ---------------------------------------------------------------------------
+# all_reduce_perf execution and parsing
+# ---------------------------------------------------------------------------
+def parse_all_reduce_output(output):
+    """Parse all_reduce_perf tabular output.
+
+    Returns list of dicts with keys:
+        size, count, data_type, redop, root, time_us, algbw_gbs, busbw_gbs
+    """
+    rows = []
+    in_data = False
+    for line in output.strip().split("\n"):
+        stripped = line.strip()
+        # Data lines start with a number (size column)
+        if stripped and stripped[0].isdigit() and not stripped.startswith("#"):
+            parts = stripped.split()
+            if len(parts) >= 8:
+                try:
+                    rows.append({
+                        "size": int(parts[0]),
+                        "count": int(parts[1]),
+                        "data_type": parts[2],
+                        "redop": parts[3],
+                        "root": int(parts[4]) if parts[4].isdigit() else 0,
+                        "time_us": float(parts[5]),
+                        "algbw_gbs": float(parts[6]),
+                        "busbw_gbs": float(parts[7]),
+                    })
+                except (ValueError, IndexError):
+                    continue
+            in_data = True
+        elif in_data and not stripped:
+            break  # end of data section
+    return rows
+
+
+def _human_bytes(n):
+    """Format byte count for display: 8, 16, ..., 1K, ..., 128M."""
+    if n < 1024:
+        return str(n)
+    elif n < 1024 * 1024:
+        return f"{n // 1024}K"
+    elif n < 1024 * 1024 * 1024:
+        return f"{n // (1024 * 1024)}M"
+    else:
+        return f"{n // (1024 * 1024 * 1024)}G"
+
+
+def run_all_reduce(group_pods, vendor, display_names, gpu_count,
+                   mpirun_path="mpirun", key_path=None, nccl_lib_path=None):
+    """Run all_reduce_perf across a group of same-vendor pods.
+
+    Returns parsed results list or None on failure.
+    """
+    if not group_pods:
+        return None
+
+    first_pod = group_pods[0][0]
+    n_pods = len(group_pods)
+    total_gpus = n_pods * gpu_count
+
+    # Build host list: ip:slots
+    host_list = ",".join(f"{ip}:{gpu_count}" for _name, ip in group_pods)
+
+    # Determine binary path
+    binary = NCCL_BINARY if vendor == "nvidia" else RCCL_BINARY
+
+    # Build LD_LIBRARY_PATH: prefer pip NCCL lib (matched to container CUDA)
+    # over system NCCL (which may be compiled for a newer CUDA).
+    ld_prefix = ""
+    if nccl_lib_path:
+        ld_prefix += f"{nccl_lib_path}:"
+    ld_prefix += "/usr/lib64"
+
+    mpi_cmd = (
+        f"{mpirun_path} --allow-run-as-root "
+        f"-np {total_gpus} -N {gpu_count} "
+        f"-H {host_list} "
+        f"-x LD_LIBRARY_PATH={ld_prefix}:$LD_LIBRARY_PATH "
+        f"-x PATH=/usr/local/bin:/usr/local/cuda/bin:/usr/bin:/usr/sbin:/bin:/sbin:$PATH "
+    )
+
+    # Add NCCL/RCCL-specific env vars.
+    # NCCL_SOCKET_IFNAME=eth0 forces NCCL to use the pod network, not
+    # service/secondary IPs that aren't routable between pods.
+    # NCCL_IB_DISABLE=1 forces socket transport — IB/RoCE may have
+    # connectivity issues in some clusters (vendor err 129 / status 12).
+    # For IB testing, run with NCCL_IB_DISABLE=0 explicitly.
+    if vendor == "nvidia":
+        mpi_cmd += (
+            "-x NCCL_DEBUG=WARN -x NCCL_SOCKET_IFNAME=eth0 "
+            "-x NCCL_IB_DISABLE=1 "
+        )
+    else:
+        mpi_cmd += (
+            "-x RCCL_DEBUG=WARN -x NCCL_SOCKET_IFNAME=eth0 "
+            "-x NCCL_IB_DISABLE=1 "
+        )
+
+    # Force MPI communication over the pod network (eth0) — without this,
+    # MPI/UCX may try secondary interfaces (e.g. service IPs) that aren't
+    # routable between pods.
+    # --mca pml ob1: use OB1 PML (not UCX PML which picks wrong interfaces)
+    # --mca btl tcp,self: restrict BTL to TCP sockets
+    # --mca btl_tcp_if_include eth0: limit TCP BTL to pod network
+    # --mca oob_tcp_if_include eth0: limit OOB (out-of-band) to pod network
+    mpi_cmd += (
+        f"--mca pml ob1 "
+        f"--mca btl tcp,self "
+        f"--mca btl_tcp_if_include eth0 "
+        f"--mca oob_tcp_if_include eth0 "
+        f"--mca plm_rsh_args '-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null{' -i ' + key_path if key_path else ''}' "
+        f"{binary} -b {AR_MIN_BYTES} -e {AR_MAX_BYTES} -f {AR_FACTOR} -g {AR_GPUS_PER_PROC}"
+    )
+
+    vendor_label = "NCCL" if vendor == "nvidia" else "RCCL"
+    pod_names = ", ".join(display_names.get(name, name) for name, _ in group_pods)
+    print(f"\n  Running {vendor_label} all_reduce_perf across {n_pods} pods "
+          f"({total_gpus} GPUs): {pod_names}")
+
+    if _get_common().VERBOSE:
+        print(f"  $ {mpi_cmd}")
+
+    try:
+        result = exec_in_pod(first_pod, ["bash", "-c", mpi_cmd], timeout=600, use_debug=False)
+    except subprocess.TimeoutExpired:
+        print(f"  all_reduce_perf TIMED OUT after 600s")
+        print(f"  This may indicate a NCCL communication hang between pods.")
+        print(f"  Try running with -v for the full mpirun command, or reduce message sizes.")
+        return None
+
+    if result.returncode != 0:
+        print(f"  all_reduce_perf FAILED (exit {result.returncode})")
+        combined = (result.stdout or "") + (result.stderr or "")
+        if "CUDA driver version is insufficient" in combined:
+            print(f"  Cause: CUDA driver/runtime version mismatch on one or more pods.")
+            print(f"  The nccl-tests binary was compiled against a CUDA runtime newer than")
+            print(f"  the GPU driver installed on the node. Check `nvidia-smi` on each pod.")
+        if result.stderr.strip():
+            print(f"  stderr (last 1000 chars): {result.stderr.strip()[-1000:]}")
+        if result.stdout.strip():
+            print(f"  stdout (last 1000 chars): {result.stdout.strip()[-1000:]}")
+        return None
+
+    # Print raw output if verbose
+    if _get_common().VERBOSE:
+        print(f"\n  Raw output:\n{result.stdout}")
+
+    rows = parse_all_reduce_output(result.stdout)
+    if not rows:
+        print("  Warning: no data rows parsed from all_reduce_perf output.")
+        if result.stdout.strip():
+            print(f"  Output:\n{result.stdout.strip()[-1000:]}")
+        return None
+
+    return rows
+
+
+def print_all_reduce_results(rows, vendor, n_pods, total_gpus):
+    """Print all_reduce_perf results as a formatted table."""
+    vendor_label = "NCCL" if vendor == "nvidia" else "RCCL"
+    print(f"\n  {vendor_label} all_reduce_perf ({n_pods} {vendor.upper()} pods, "
+          f"{total_gpus} GPUs total):")
+    print(f"  {'Size':>10s}  {'Count':>12s}  {'Time(us)':>12s}  "
+          f"{'AlgBW(GB/s)':>12s}  {'BusBW(GB/s)':>12s}")
+    print(f"  {'─' * 10}  {'─' * 12}  {'─' * 12}  {'─' * 12}  {'─' * 12}")
+    for r in rows:
+        size_str = _human_bytes(r["size"])
+        print(f"  {size_str:>10s}  {r['count']:>12d}  {r['time_us']:>12.2f}  "
+              f"{r['algbw_gbs']:>12.2f}  {r['busbw_gbs']:>12.2f}")
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+def run_nccl_rccl(pods, display_names):
+    """Run NCCL/RCCL all_reduce_perf tests.
+
+    1. Detect GPU vendor per pod (parallel)
+    2. Group by vendor
+    3. Ensure tests built (parallel per group)
+    4. Setup SSH, run all_reduce, teardown SSH
+    5. Return results dict
+    """
+    _c = _get_common()
+
+    print(f"\n{'=' * 60}")
+    print("  NCCL/RCCL COLLECTIVE TESTS (all_reduce_perf)")
+    print(f"{'=' * 60}")
+
+    # Step 1: Detect GPU vendors
+    print("\nDetecting GPU vendors on all pods ...")
+    vendors = detect_all_gpu_vendors(pods)
+
+    # Group pods by vendor
+    nvidia_pods = [(name, ip) for name, ip in pods if vendors.get(name) == "nvidia"]
+    amd_pods = [(name, ip) for name, ip in pods if vendors.get(name) == "amd"]
+    unknown_pods = [(name, ip) for name, ip in pods if vendors.get(name) not in ("nvidia", "amd")]
+
+    if unknown_pods:
+        print(f"\n  Skipping {len(unknown_pods)} pod(s) with unknown GPU vendor: "
+              f"{', '.join(display_names.get(n, n) for n, _ in unknown_pods)}")
+
+    if not nvidia_pods and not amd_pods:
+        print("\n  No pods with recognized GPUs found. Skipping NCCL/RCCL tests.")
+        return {}
+
+    all_results = {}
+
+    for vendor, group_pods in [("nvidia", nvidia_pods), ("amd", amd_pods)]:
+        if not group_pods:
+            continue
+
+        vendor_label = "NCCL" if vendor == "nvidia" else "RCCL"
+        print(f"\n{'─' * 50}")
+        print(f"  {vendor_label} tests — {len(group_pods)} {vendor.upper()} pods")
+        print(f"{'─' * 50}")
+
+        # Detect GPU count
+        print("\n  Detecting GPU count ...")
+        gpu_counts = {}
+        for name, _ip in group_pods:
+            count = detect_gpu_count(name, vendor)
+            gpu_counts[name] = count
+            print(f"    {display_names.get(name, name)}: {count} GPUs")
+
+        counts_set = set(gpu_counts.values())
+        if 0 in counts_set:
+            zero_pods = [display_names.get(n, n) for n, _ in group_pods if gpu_counts[n] == 0]
+            print(f"  Warning: GPU count is 0 on: {', '.join(zero_pods)}. Skipping.")
+            continue
+        if len(counts_set) > 1:
+            print(f"  Warning: GPU count varies across pods: {counts_set}. "
+                  f"All pods must have the same GPU count. Skipping.")
+            continue
+
+        gpu_count = counts_set.pop()
+        total_gpus = len(group_pods) * gpu_count
+        print(f"  {gpu_count} GPUs per pod, {total_gpus} total")
+
+        # Pre-flight: check CUDA driver/runtime compatibility on all pods
+        if vendor == "nvidia":
+            print("\n  Checking CUDA driver/runtime compatibility ...")
+            cuda_ok = True
+            for name, _ip in group_pods:
+                result = exec_in_pod(name, ["bash", "-c",
+                    "python3 -c 'import torch; torch.cuda.init(); "
+                    "print(f\"driver={torch.version.cuda}, "
+                    "runtime={torch.version.cuda}\")' 2>&1 || "
+                    "nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -1"
+                ], timeout=30, use_debug=False)
+                out_str = (result.stdout or "").strip()
+                if "error" in out_str.lower() or "insufficient" in out_str.lower():
+                    print(f"    {display_names.get(name, name)}: CUDA MISMATCH — {out_str[:200]}")
+                    cuda_ok = False
+                else:
+                    print(f"    {display_names.get(name, name)}: {out_str[:100]}")
+            if not cuda_ok:
+                print(f"  Warning: CUDA driver/runtime mismatch detected. "
+                      f"all_reduce_perf may fail on affected pods.")
+
+        n = len(group_pods)
+
+        # Step A: Install build deps (git, make, gcc, openmpi-devel) on all pods.
+        # This must happen BEFORE building nccl/rccl-tests because `make MPI=1`
+        # needs MPI headers at compile time.
+        if _c.INSTALL_DEPS:
+            print(f"\n  Installing build dependencies (git, make, gcc, OpenMPI) ...")
+            dep_bufs = [_c._StreamingBuffer() for _ in range(n)]
+            dep_done = [threading.Event() for _ in range(n)]
+
+            def _dep_worker(idx, pod_name, buf, done_evt):
+                try:
+                    install_build_deps(pod_name, out=lambda msg: buf.write(msg + "\n"))
+                except Exception as exc:
+                    buf.write(f"  ERROR installing deps on {pod_name}: {exc}\n")
+                finally:
+                    done_evt.set()
+
+            dep_threads = []
+            for idx, (name, _ip) in enumerate(group_pods):
+                t = threading.Thread(
+                    target=_dep_worker,
+                    args=(idx, name, dep_bufs[idx], dep_done[idx]),
+                    daemon=True,
+                )
+                dep_threads.append(t)
+                t.start()
+
+            for idx in range(n):
+                while not dep_done[idx].is_set():
+                    dep_bufs[idx].flush_new()
+                    dep_done[idx].wait(timeout=0.1)
+                dep_bufs[idx].flush_all()
+
+            for t in dep_threads:
+                t.join(timeout=5)
+
+        # Step B: Ensure nccl/rccl-tests are built (parallel)
+        print(f"\n  Ensuring {vendor_label.lower()}-tests are available ...")
+        bufs = [_c._StreamingBuffer() for _ in range(n)]
+        done_events = [threading.Event() for _ in range(n)]
+        build_ok = [False] * n
+
+        def _build_worker(idx, pod_name, v, buf, done_evt):
+            try:
+                build_ok[idx] = ensure_collective_tests(
+                    pod_name, v, out=lambda msg: buf.write(msg + "\n")
+                )
+            except Exception as exc:
+                buf.write(f"  ERROR on {pod_name}: {exc}\n")
+            finally:
+                done_evt.set()
+
+        threads = []
+        for idx, (name, _ip) in enumerate(group_pods):
+            t = threading.Thread(
+                target=_build_worker,
+                args=(idx, name, vendor, bufs[idx], done_events[idx]),
+                daemon=True,
+            )
+            threads.append(t)
+            t.start()
+
+        for idx in range(n):
+            while not done_events[idx].is_set():
+                bufs[idx].flush_new()
+                done_events[idx].wait(timeout=0.1)
+            bufs[idx].flush_all()
+
+        for t in threads:
+            t.join(timeout=5)
+
+        if not all(build_ok):
+            failed = [display_names.get(group_pods[i][0], group_pods[i][0])
+                      for i in range(n) if not build_ok[i]]
+            print(f"  Warning: {vendor_label.lower()}-tests not available on: "
+                  f"{', '.join(failed)}. Skipping {vendor_label} tests.")
+            continue
+
+        # Detect pip NCCL lib path for runtime LD_LIBRARY_PATH.
+        # The system NCCL at /lib64/ may be compiled for a newer CUDA
+        # (e.g., 2.29.7+cuda13.2) than the driver supports. The pip
+        # nvidia-nccl package is typically matched to the container's CUDA.
+        _, nccl_lib_path = _find_nccl_paths(group_pods[0][0])
+        if nccl_lib_path and nccl_lib_path != "/usr/lib64":
+            print(f"  Using pip NCCL lib: {nccl_lib_path}")
+
+        # Step C: Find mpirun path (already installed by build deps above)
+        mpirun_path = find_mpirun(group_pods[0][0])
+        if not mpirun_path:
+            # Last resort: try install_mpi which searches harder
+            mpirun_path = install_mpi(group_pods[0][0])
+        if not mpirun_path:
+            print(f"  Error: mpirun not available on {group_pods[0][0]}. "
+                  f"Skipping {vendor_label} tests.")
+            continue
+        print(f"  Using mpirun: {mpirun_path}")
+
+        # Setup SSH
+        print(f"\n  Setting up SSH cluster for mpirun ...")
+        ssh_result = setup_ssh_cluster(group_pods)
+        if isinstance(ssh_result, tuple):
+            ssh_ok, key_path = ssh_result
+        else:
+            ssh_ok, key_path = ssh_result, None
+        ssh_dir = str(key_path).rsplit("/", 1)[0] if key_path else None
+        if not ssh_ok:
+            print(f"  Warning: SSH setup incomplete. Attempting to run anyway ...")
+
+        # Run all_reduce_perf
+        try:
+            rows = run_all_reduce(group_pods, vendor, display_names, gpu_count,
+                                  mpirun_path=mpirun_path, key_path=key_path,
+                                  nccl_lib_path=nccl_lib_path)
+        finally:
+            # Always teardown SSH
+            stop_sshd_all(group_pods, ssh_dir=ssh_dir)
+
+        if rows:
+            print_all_reduce_results(rows, vendor, len(group_pods), total_gpus)
+
+            # Store max busbw as the headline metric
+            max_busbw = max(r["busbw_gbs"] for r in rows)
+            max_algbw = max(r["algbw_gbs"] for r in rows)
+            print(f"\n  Peak Bus BW: {max_busbw:.2f} GB/s")
+            print(f"  Peak Algorithm BW: {max_algbw:.2f} GB/s")
+
+            all_results[f"{vendor_label} all_reduce BusBW (GB/s)"] = rows
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point — allows:  uv run run-tests-nccl-rccl.py [options]
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    _USAGE = """\
+Usage: uv run run-tests-nccl-rccl.py [options]
+
+Run NCCL/RCCL all_reduce_perf collective tests between Kubernetes
+inference pods.
+
+Equivalent to: run-tests.sh -t nccl-rccl
+
+Detects GPU vendor per pod (NVIDIA/AMD), builds nccl-tests or rccl-tests
+from source if needed, sets up passwordless SSH for mpirun, runs
+all_reduce_perf, and displays results.
+
+Options:
+  -D, --debug-image IMAGE
+                        Use ephemeral debug containers with the given image.
+  -e, --explain         Show the kubectl/shell commands behind each finding.
+  -h, --help            Show this help message.
+  -i, --install-deps    Build nccl-tests/rccl-tests from source if missing.
+  -l, --label SELECTOR  Label selector to discover pods
+                        (default: "llm-d.ai/inferenceServing=true").
+  -n, --namespace NS    Kubernetes namespace for all kubectl commands.
+  -p, --percentage-margin PCT
+                        Flag results deviating more than PCT% from average
+                        (default: 10).
+  -v, --verbose         Print kubectl commands as they run.
+  -x, --explain-verify  Run each explain command and verify output.
+                        Implies --explain.
+"""
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print(_USAGE)
+        sys.exit(0)
+
+    _c = _get_common()
+    _cfg = _c._parse_common_args()
+    _c.configure(**_cfg)
+
+    _pods, _display_names = _c._discover_and_display()
+    if _c.USE_DEBUG_CONTAINER:
+        print("\nCreating debug containers ...")
+        _c.create_debug_containers(_pods)
+
+    _results = run_nccl_rccl(_pods, _display_names)
+
+    # Print summary if there are tabular results
+    for _title, _rows in _results.items():
+        if isinstance(_rows, list) and _rows:
+            print(f"\n{_title} — summary:")
+            max_busbw = max(r["busbw_gbs"] for r in _rows)
+            max_algbw = max(r["algbw_gbs"] for r in _rows)
+            print(f"  Peak Bus BW: {max_busbw:.2f} GB/s")
+            print(f"  Peak Algorithm BW: {max_algbw:.2f} GB/s")

--- a/run-tests-nixlbench.py
+++ b/run-tests-nixlbench.py
@@ -1,0 +1,1199 @@
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""NIXLBench runner for Kubernetes inference pods.
+
+Runs nixlbench (NIXL data transfer benchmark) between pods using ETCD for
+worker coordination.  Measures RDMA/GPU memory transfer throughput and latency
+between pod pairs.
+
+With --install-deps, builds nixlbench from source inside pods (requires CUDA
+and UCX to be present in the container image).  Otherwise expects nixlbench
+to be pre-installed.
+
+Public API:
+    run_nixlbench(pods, display_names) -> dict
+    ensure_nixlbench(pod_name) -> None
+    install_etcd(pod_name) -> None
+    build_nixlbench_from_source(pod_name) -> bool
+"""
+
+import subprocess
+import sys
+import threading
+import time
+
+from importlib import import_module
+
+# Import shared utilities from the common module.
+_common = None
+
+
+def _get_common():
+    global _common
+    if _common is None:
+        _common = import_module("run-tests-common")
+    return _common
+
+
+# Delegated to run-tests-common
+def run_cmd(*args, **kwargs):
+    return _get_common().run_cmd(*args, **kwargs)
+
+
+def exec_in_pod(*args, **kwargs):
+    return _get_common().exec_in_pod(*args, **kwargs)
+
+
+# ---------------------------------------------------------------------------
+# NIXLBench constants
+# ---------------------------------------------------------------------------
+ETCD_VER = "v3.5.21"
+ETCD_DOWNLOAD_URL = (
+    f"https://github.com/etcd-io/etcd/releases/download/{ETCD_VER}"
+    f"/etcd-{ETCD_VER}-linux-amd64.tar.gz"
+)
+ETCD_PORT = 2379
+NIXLBENCH_BINARY = "nixlbench"
+NIXLBENCH_TIMEOUT = 600  # 10 minutes per pair
+NIXL_REPO = "https://github.com/ai-dynamo/nixl.git"
+NIXL_BUILD_DIR = "/tmp/nixl-build"
+NIXL_INSTALL_PREFIX = "/usr/local/nixl"
+NIXLBENCH_INSTALL_PREFIX = "/usr/local/nixlbench"
+ETCD_CPP_REPO = "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git"
+PROTOBUF_VER = "v21.12"
+GRPC_VER = "v1.46.7"
+
+# Defaults — overridden via configure() from run-tests.py
+NIXLBENCH_BACKEND = "UCX"
+NIXLBENCH_SEG_TYPE = "VRAM"
+NIXLBENCH_BUFFER_SIZE = "8G"
+
+
+# ---------------------------------------------------------------------------
+# Binary checks
+# ---------------------------------------------------------------------------
+def _check_binary(pod_name, binary):
+    """Check if a binary is available on a pod. Returns True if found."""
+    # Include nixlbench install paths in case it was built from source
+    # For nixlbench, also verify shared libraries can load (ldd check)
+    env_prefix = (
+        f'export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:'
+        f'/usr/local/bin:$PATH && '
+        f'export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:'
+        f'{NIXLBENCH_INSTALL_PREFIX}/lib64:'
+        f'{NIXL_INSTALL_PREFIX}/lib64:'
+        f'{NIXL_INSTALL_PREFIX}/lib64/plugins:'
+        f'{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu:'
+        f'{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu/plugins:'
+        f'/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}}'
+    )
+    if binary == NIXLBENCH_BINARY:
+        # For nixlbench: verify both found AND shared libs resolve
+        check_cmd = (
+            f'{env_prefix} && '
+            f'if ! command -v {binary} >/dev/null 2>&1; then echo "MISSING"; '
+            f'elif ldd $(command -v {binary}) 2>&1 | grep -q "not found"; then echo "MISSING_LIBS"; '
+            f'else echo "FOUND"; fi'
+        )
+    else:
+        check_cmd = (
+            f'{env_prefix} && '
+            f'command -v {binary} >/dev/null 2>&1 && echo "FOUND" || echo "MISSING"'
+        )
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", check_cmd],
+        use_debug=False,
+    )
+    if binary == NIXLBENCH_BINARY:
+        return result.returncode == 0 and "FOUND" in result.stdout and "MISSING_LIBS" not in result.stdout
+    return result.returncode == 0 and "FOUND" in result.stdout
+
+
+def _check_etcd_runtime(pod_name):
+    """Check if nixlbench was built with ETCD runtime support."""
+    env_prefix = (
+        f'export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:'
+        f'/usr/local/bin:$PATH && '
+        f'export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:'
+        f'{NIXLBENCH_INSTALL_PREFIX}/lib64:'
+        f'{NIXL_INSTALL_PREFIX}/lib64:{NIXL_INSTALL_PREFIX}/lib64/plugins:'
+        f'/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}}'
+    )
+    # Run nixlbench with --etcd_endpoints dummy to check if ETCD runtime is valid
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         f'{env_prefix} && nixlbench --etcd_endpoints http://127.0.0.1:1 '
+         f'--benchmark_group test 2>&1 | head -5'],
+        timeout=10, use_debug=False,
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    # "Invalid runtime: ETCD" means ETCD runtime was not compiled in
+    return "Invalid runtime" not in output
+
+
+def ensure_nixlbench(pod_name, out=None):
+    """Verify nixlbench binary is available; build from source if --install-deps."""
+    _out = out or print
+    if _check_binary(pod_name, NIXLBENCH_BINARY):
+        # Also verify ETCD runtime is available
+        if _check_etcd_runtime(pod_name):
+            _out(f"  nixlbench binary available on {pod_name} (with ETCD runtime).")
+            return
+        elif _get_common().INSTALL_DEPS:
+            _out(f"  nixlbench found but lacks ETCD runtime on {pod_name}, rebuilding ...")
+        else:
+            _out(f"  Warning: nixlbench on {pod_name} lacks ETCD runtime.")
+            _out(f"  Re-run with --install-deps (-i) to rebuild with ETCD support.")
+            sys.exit(1)
+    if not _get_common().INSTALL_DEPS:
+        _out(f"  Error: nixlbench binary not found on {pod_name}.")
+        _out(f"  Re-run with --install-deps (-i) to build from source,")
+        _out(f"  or use a pod image with nixlbench pre-installed.")
+        _out(f"  See https://github.com/ai-dynamo/nixl/tree/main/benchmark/nixlbench")
+        sys.exit(1)
+    _out(f"  nixlbench not found on {pod_name}, building from source ...")
+    if not build_nixlbench_from_source(pod_name, out=_out):
+        _out(f"  Error: failed to build nixlbench on {pod_name}.")
+        sys.exit(1)
+    if not _check_binary(pod_name, NIXLBENCH_BINARY):
+        _out(f"  Error: nixlbench still not available after build on {pod_name}.")
+        sys.exit(1)
+    _out(f"  nixlbench built and installed successfully on {pod_name}.")
+
+
+# ---------------------------------------------------------------------------
+# Build from source
+# ---------------------------------------------------------------------------
+def _run_build_step(pod_name, cmd, label, out, timeout=600, ignore_error=False):
+    """Run a build step inside the pod. Returns True on success."""
+    _out = out or print
+    _out(f"    [{label}] ...")
+    # Ensure /usr/local/bin is on PATH (pip installs meson/ninja there)
+    # Also set PKG_CONFIG_PATH for locally-built libraries
+    cmd_with_path = (
+        f'export PATH=/usr/local/bin:$PATH && '
+        f'export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:${{PKG_CONFIG_PATH:-}} && '
+        f'{cmd}'
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", cmd_with_path], timeout=timeout, use_debug=False)
+    if _get_common().VERBOSE and result.stdout.strip():
+        _out(result.stdout[-500:])
+    if result.returncode != 0:
+        if ignore_error:
+            _out(f"    [{label}] warning (exit {result.returncode}, ignored)")
+            return True
+        _out(f"    [{label}] FAILED (exit {result.returncode})")
+        stderr = result.stderr.strip()
+        if stderr:
+            _out(f"    stderr: {stderr[-500:]}")
+        return False
+    return True
+
+
+def install_nixlbench_deps(pod_name, out=None):
+    """Install system packages and Python build tools needed for nixlbench."""
+    _out = out or print
+    _out(f"  Installing build dependencies on {pod_name} ...")
+
+    # Package groups by distro family — installed one group at a time so a
+    # failure in one doesn't block the rest.
+    # Install each package individually to avoid one missing package
+    # blocking the rest.  RHEL 9 UBI repos have limited -devel packages.
+    rpm_groups = [
+        ("gcc gcc-c++ ninja-build cmake pkgconfig git python3-pip",
+         "core build tools"),
+        ("rdma-core-devel",
+         "RDMA core development headers"),
+        ("gflags-devel",
+         "gflags (required by nixlbench)"),
+        ("openssl-devel",
+         "OpenSSL development headers (for etcd-cpp-apiv3)"),
+        ("re2-devel zlib-devel",
+         "re2 and zlib development headers (for gRPC)"),
+    ]
+    apt_groups = [
+        ("build-essential ninja-build cmake pkg-config git python3-pip",
+         "core build tools"),
+        ("libibverbs-dev librdmacm-dev rdma-core ibverbs-utils "
+         "libibumad-dev ibverbs-providers libnuma-dev",
+         "RDMA/IB development headers"),
+        ("libgflags-dev libaio-dev liburing-dev libz-dev pybind11-dev",
+         "I/O and misc libraries"),
+        ("libssl-dev libprotobuf-dev protobuf-compiler protobuf-compiler-grpc "
+         "libgrpc++-dev libcpprest-dev",
+         "protobuf/gRPC/OpenSSL (for etcd support)"),
+    ]
+
+    # Detect package manager
+    for pkg_mgr, install_cmd in [
+        ("dnf", "dnf install -y"),
+        ("yum", "yum install -y"),
+    ]:
+        check = exec_in_pod(pod_name, ["which", pkg_mgr], use_debug=False)
+        if check.returncode == 0:
+            _out(f"    Detected {pkg_mgr} package manager")
+            for pkgs, label in rpm_groups:
+                result = exec_in_pod(
+                    pod_name, ["bash", "-c", f"{install_cmd} {pkgs}"],
+                    timeout=300, use_debug=False,
+                )
+                if result.returncode != 0:
+                    _out(f"    Warning: failed to install {label}: {result.stderr.strip()[:200]}")
+                else:
+                    stdout = (result.stdout or "").lower()
+                    if "already installed" in stdout or "nothing to do" in stdout:
+                        _out(f"    Skipped {label} (already installed).")
+                    else:
+                        _out(f"    Installed {label}.")
+            break
+    else:
+        # Debian/Ubuntu — apt-get
+        exec_in_pod(pod_name, ["apt-get", "update", "-y"], timeout=120, use_debug=False)
+        for pkgs, label in apt_groups:
+            result = exec_in_pod(
+                pod_name,
+                ["bash", "-c", f"DEBIAN_FRONTEND=noninteractive apt-get install -y {pkgs}"],
+                timeout=300, use_debug=False,
+            )
+            if result.returncode != 0:
+                _out(f"    Warning: failed to install {label}: {result.stderr.strip()[:200]}")
+            else:
+                stdout = (result.stdout or "").lower()
+                if "already the newest" in stdout:
+                    _out(f"    Skipped {label} (already installed).")
+                else:
+                    _out(f"    Installed {label}.")
+
+    # Python build tools — try pip3 first, then python3 -m pip
+    _out(f"    Installing Python build tools (meson, pybind11, tomlkit) ...")
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         "pip3 install meson pybind11 tomlkit 2>/dev/null || "
+         "python3 -m pip install meson pybind11 tomlkit"],
+        timeout=120, use_debug=False,
+    )
+    if result.returncode != 0:
+        _out(f"    Warning: pip install failed: {result.stderr.strip()[:200]}")
+    else:
+        _out(f"    Installed Python build tools.")
+
+    _out(f"  Build dependencies installed on {pod_name}.")
+    return True
+
+
+def _check_lib_installed(pod_name, pkg_config_name, lib_paths):
+    """Check if a library is installed via pkg-config or file existence."""
+    checks = [f"pkg-config --exists {pkg_config_name} 2>/dev/null"]
+    for p in lib_paths:
+        checks.append(f"test -f {p}")
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", " || ".join(checks)],
+        use_debug=False,
+    )
+    return result.returncode == 0
+
+
+def _clean_build_dir(pod_name, build_dir, out):
+    """Clean a build directory, handling stubborn permissions."""
+    _run_build_step(
+        pod_name,
+        f"chmod -R u+rwx {build_dir} 2>/dev/null; rm -rf {build_dir}",
+        "clean", out, ignore_error=True,
+    )
+
+
+def build_protobuf(pod_name, out=None):
+    """Build protobuf from source (required by gRPC and etcd-cpp-apiv3)."""
+    _out = out or print
+    if _check_lib_installed(pod_name, "protobuf",
+                            ["/usr/local/lib64/libprotobuf.so",
+                             "/usr/local/lib/libprotobuf.so"]):
+        _out(f"    protobuf already installed.")
+        return True
+    _out(f"  Building protobuf on {pod_name} ...")
+    build_dir = f"{NIXL_BUILD_DIR}/protobuf"
+    _clean_build_dir(pod_name, build_dir, _out)
+    steps = [
+        (f"git clone --depth 1 --branch {PROTOBUF_VER} "
+         f"https://github.com/protocolbuffers/protobuf.git {build_dir}",
+         "clone protobuf", 120),
+        (f"cd {build_dir} && git submodule update --init --recursive",
+         "init submodules", 120),
+        (f"mkdir -p {build_dir}/build && cd {build_dir}/build && "
+         f"cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local "
+         f"-DCMAKE_POSITION_INDEPENDENT_CODE=ON "
+         f"-Dprotobuf_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
+         "cmake configure", 120),
+        (f"cd {build_dir}/build && make -j$(nproc)", "build", 600),
+        (f"cd {build_dir}/build && make install && ldconfig", "install", 120),
+    ]
+    for cmd, label, t in steps:
+        if not _run_build_step(pod_name, cmd, label, _out, timeout=t):
+            _out(f"  Warning: protobuf build failed at '{label}'.")
+            return False
+    _out(f"  protobuf built and installed on {pod_name}.")
+    return True
+
+
+def build_grpc(pod_name, out=None):
+    """Build gRPC from source with bundled abseil (required by etcd-cpp-apiv3)."""
+    _out = out or print
+    if _check_lib_installed(pod_name, "grpc++",
+                            ["/usr/local/lib/libgrpc++.so",
+                             "/usr/local/lib64/libgrpc++.so"]):
+        _out(f"    gRPC already installed.")
+        return True
+    _out(f"  Building gRPC on {pod_name} (this may take several minutes) ...")
+    build_dir = f"{NIXL_BUILD_DIR}/grpc"
+    _clean_build_dir(pod_name, build_dir, _out)
+    steps = [
+        (f"git clone --depth 1 --branch {GRPC_VER} "
+         f"https://github.com/grpc/grpc.git {build_dir}",
+         "clone gRPC", 120),
+        # Init only needed submodules: abseil and c-ares
+        (f"cd {build_dir} && git submodule update --init "
+         f"third_party/abseil-cpp third_party/cares/cares",
+         "init submodules", 120),
+        (f"mkdir -p {build_dir}/build && cd {build_dir}/build && "
+         f"cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local "
+         f"-DBUILD_SHARED_LIBS=ON -DgRPC_INSTALL=ON "
+         f"-DgRPC_BUILD_TESTS=OFF "
+         f"-DgRPC_PROTOBUF_PROVIDER=package "
+         f"-DgRPC_ABSL_PROVIDER=module "
+         f"-DgRPC_CARES_PROVIDER=module "
+         f"-DgRPC_RE2_PROVIDER=package "
+         f"-DgRPC_SSL_PROVIDER=package "
+         f"-DgRPC_ZLIB_PROVIDER=package "
+         f"-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
+         "cmake configure", 120),
+        (f"cd {build_dir}/build && make -j$(nproc)", "build", 900),
+        (f"cd {build_dir}/build && cmake --install . && ldconfig", "install", 120),
+        # Remove gRPC's bundled abseil pkg-config files so they don't conflict
+        # with NIXL's meson subproject abseil (which is much newer).
+        # gRPC itself links abseil statically via its module provider.
+        (f"rm -f /usr/local/lib/pkgconfig/absl_*.pc "
+         f"/usr/local/lib64/pkgconfig/absl_*.pc 2>/dev/null; "
+         f"dnf remove -y abseil-cpp abseil-cpp-devel 2>/dev/null; true",
+         "clean abseil pkg-config", 60),
+    ]
+    for cmd, label, t in steps:
+        if not _run_build_step(pod_name, cmd, label, _out, timeout=t):
+            _out(f"  Warning: gRPC build failed at '{label}'.")
+            return False
+    _out(f"  gRPC built and installed on {pod_name}.")
+    return True
+
+
+def build_etcd_cpp_api(pod_name, out=None):
+    """Build etcd-cpp-apiv3 from source (required for nixlbench etcd runtime).
+
+    Requires protobuf and gRPC to be installed first.  Builds them from source
+    if not already present (RHEL 9 UBI repos lack these C++ packages).
+    """
+    _out = out or print
+
+    # Check if already installed
+    if _check_lib_installed(pod_name, "etcd-cpp-api",
+                            ["/usr/local/lib64/libetcd-cpp-api-core.so",
+                             "/usr/local/lib/libetcd-cpp-api-core.so"]):
+        _out(f"    etcd-cpp-apiv3 already available.")
+        return True
+
+    _out(f"  Building etcd stack (protobuf -> gRPC -> etcd-cpp-apiv3) ...")
+
+    # Step 1: Build protobuf from source
+    if not build_protobuf(pod_name, out=_out):
+        _out(f"  Cannot build etcd-cpp-apiv3 without protobuf.")
+        return False
+
+    # Step 2: Build gRPC from source
+    if not build_grpc(pod_name, out=_out):
+        _out(f"  Cannot build etcd-cpp-apiv3 without gRPC.")
+        return False
+
+    # Step 3: Build etcd-cpp-apiv3
+    _out(f"  Building etcd-cpp-apiv3 on {pod_name} ...")
+    build_dir = f"{NIXL_BUILD_DIR}/etcd-cpp-apiv3"
+    _clean_build_dir(pod_name, build_dir, _out)
+    steps = [
+        (f"git clone --depth 1 {ETCD_CPP_REPO} {build_dir}",
+         "clone etcd-cpp-apiv3", 120),
+        (f"mkdir -p {build_dir}/build && cd {build_dir}/build && "
+         f"cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON "
+         f"-DBUILD_ETCD_TESTS=OFF -DBUILD_ETCD_CORE_ONLY=ON "
+         f"-DCMAKE_PREFIX_PATH=/usr/local",
+         "cmake configure", 120),
+        (f"cd {build_dir}/build && make -j$(nproc)", "build", 300),
+        (f"cd {build_dir}/build && make install && ldconfig", "install", 120),
+    ]
+    for cmd, label, t in steps:
+        if not _run_build_step(pod_name, cmd, label, _out, timeout=t):
+            _out(f"  Warning: etcd-cpp-apiv3 build failed at '{label}'.")
+            _out(f"  nixlbench will be built without etcd runtime support.")
+            return False
+
+    # Create pkg-config file (meson needs it to find etcd-cpp-api)
+    pkgconfig_cmd = (
+        'mkdir -p /usr/local/lib64/pkgconfig && '
+        'cat > /usr/local/lib64/pkgconfig/etcd-cpp-api.pc << "PKGEOF"\n'
+        'prefix=/usr/local\n'
+        'exec_prefix=${prefix}\n'
+        'libdir=${prefix}/lib64\n'
+        'includedir=${prefix}/include\n'
+        '\n'
+        'Name: etcd-cpp-api\n'
+        'Description: etcd C++ client API (core only)\n'
+        'Version: 0.15.4\n'
+        'Libs: -L${libdir} -letcd-cpp-api-core\n'
+        'Cflags: -I${includedir}\n'
+        'PKGEOF'
+    )
+    _run_build_step(pod_name, pkgconfig_cmd, "pkg-config file", _out, ignore_error=True)
+
+    _out(f"  etcd-cpp-apiv3 built and installed on {pod_name}.")
+    return True
+
+
+def _detect_ucx_path(pod_name):
+    """Detect UCX installation path on the pod."""
+    # Check common locations: /opt/ucx, /usr/local, /usr
+    for path in ["/opt/ucx", "/usr/local", "/usr"]:
+        result = exec_in_pod(
+            pod_name,
+            ["bash", "-c", f"test -f {path}/lib/libucp.so && echo FOUND"],
+            use_debug=False,
+        )
+        if result.returncode == 0 and "FOUND" in result.stdout:
+            return path
+    return None
+
+
+def build_nixl(pod_name, out=None):
+    """Clone and build NIXL library from source (UCX plugin only)."""
+    _out = out or print
+    _out(f"  Building NIXL library on {pod_name} ...")
+
+    # Detect UCX path for meson
+    ucx_path = _detect_ucx_path(pod_name)
+    if ucx_path:
+        _out(f"    Found UCX at {ucx_path}")
+    else:
+        _out(f"    Warning: UCX not found, NIXL build may fail.")
+
+    nixl_src = f"{NIXL_BUILD_DIR}/nixl"
+    meson_args = (
+        f"--prefix={NIXL_INSTALL_PREFIX} --buildtype=release "
+        f"-Denable_plugins=UCX -Dinstall_headers=true"
+    )
+    if ucx_path and ucx_path not in ("/usr", "/usr/local"):
+        meson_args += f" -Ducx_path={ucx_path}"
+
+    # Clean stale directory — chmod first to fix meson subproject perms, then rm
+    _run_build_step(
+        pod_name,
+        f"chmod -R u+rwx {nixl_src} 2>/dev/null; rm -rf {nixl_src}",
+        "clean", _out, timeout=60, ignore_error=True,
+    )
+    steps = [
+        (f"git clone --depth 1 {NIXL_REPO} {nixl_src}", "clone NIXL", 300),
+        (f"cd {nixl_src} && meson setup build {meson_args}",
+         "meson configure", 900),  # downloads abseil subproject
+        (f"cd {nixl_src}/build && ninja", "build", 900),
+        (f"cd {nixl_src}/build && ninja install", "install", 120),
+    ]
+    for cmd, label, step_timeout in steps:
+        if not _run_build_step(pod_name, cmd, label, _out, timeout=step_timeout):
+            return False
+
+    # Configure linker to find NIXL libraries.
+    # Detect actual lib dir: RHEL uses lib64, Debian uses lib/<arch>-linux-gnu
+    ldconfig_cmd = (
+        f'NIXL_LIBDIR=$(find {NIXL_INSTALL_PREFIX} -maxdepth 1 -name "lib*" -type d | head -1) && '
+        f'echo "$NIXL_LIBDIR" > /etc/ld.so.conf.d/nixl.conf && '
+        f'[ -d "$NIXL_LIBDIR/plugins" ] && echo "$NIXL_LIBDIR/plugins" >> /etc/ld.so.conf.d/nixl.conf; '
+        f'ldconfig'
+    )
+    if not _run_build_step(pod_name, ldconfig_cmd, "ldconfig", _out):
+        _out(f"    Warning: ldconfig failed, may need LD_LIBRARY_PATH at runtime.")
+
+    # Also create symlinks in /usr/local/lib64 (RHEL) or /usr/local/lib as
+    # fallback — ensures the runtime linker finds libs even without ldconfig
+    symlink_cmd = (
+        f'NIXL_LIBDIR=$(find {NIXL_INSTALL_PREFIX} -maxdepth 1 -name "lib*" -type d | head -1) && '
+        f'SYSLIB=$([ -d /usr/local/lib64 ] && echo /usr/local/lib64 || echo /usr/local/lib) && '
+        f'mkdir -p $SYSLIB && '
+        f'for f in $NIXL_LIBDIR/lib*.so*; do '
+        f'  [ -f "$f" ] && ln -sf "$f" $SYSLIB/$(basename "$f") || true; '
+        f'done; '
+        f'for f in $NIXL_LIBDIR/plugins/lib*.so*; do '
+        f'  [ -f "$f" ] && ln -sf "$f" $SYSLIB/$(basename "$f") || true; '
+        f'done; ldconfig'
+    )
+    if not _run_build_step(pod_name, symlink_cmd, "library symlinks", _out):
+        _out(f"    Warning: symlink creation failed.")
+
+    _out(f"  NIXL built and installed at {NIXL_INSTALL_PREFIX} on {pod_name}.")
+    return True
+
+
+def _build_nixlbench_binary(pod_name, out=None):
+    """Build nixlbench binary against installed NIXL."""
+    _out = out or print
+    _out(f"  Building nixlbench on {pod_name} ...")
+
+    nixlbench_src = f"{NIXL_BUILD_DIR}/nixl/benchmark/nixlbench"
+    # Set PKG_CONFIG_PATH so meson finds etcd-cpp-api and other locally-built libs
+    pkg_env = "export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+    meson_args = (
+        f"-Dnixl_path={NIXL_INSTALL_PREFIX}/ "
+        f"-Dprefix={NIXLBENCH_INSTALL_PREFIX} "
+        f"-Detcd_inc_path=/usr/local/include "
+        f"-Detcd_lib_path=/usr/local/lib64 "
+        f"--buildtype=release"
+    )
+    steps = [
+        (f"{pkg_env} && cd {nixlbench_src} && meson setup build {meson_args}",
+         "meson configure", 300),
+        (f"cd {nixlbench_src}/build && ninja", "build", 600),
+        (f"cd {nixlbench_src}/build && ninja install", "install", 120),
+    ]
+    for cmd, label, step_timeout in steps:
+        if not _run_build_step(pod_name, cmd, label, _out, timeout=step_timeout):
+            return False
+
+    # Add to PATH and LD_LIBRARY_PATH via profile.d for this session
+    env_setup = (
+        f'echo "export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:\\$PATH" '
+        f'> /etc/profile.d/nixlbench.sh && '
+        f'echo "export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:'
+        f'{NIXLBENCH_INSTALL_PREFIX}/lib64:'
+        f'{NIXL_INSTALL_PREFIX}/lib64:{NIXL_INSTALL_PREFIX}/lib64/plugins:'
+        f'{NIXL_INSTALL_PREFIX}/lib/\\$(uname -m)-linux-gnu:'
+        f'{NIXL_INSTALL_PREFIX}/lib/\\$(uname -m)-linux-gnu/plugins:'
+        f'/usr/local/lib64:/usr/local/lib:/opt/ucx/lib:'
+        f'\\$LD_LIBRARY_PATH" >> /etc/profile.d/nixlbench.sh && '
+        f'chmod +x /etc/profile.d/nixlbench.sh && '
+        # Also create symlinks in /usr/local/bin for immediate availability
+        f'ln -sf {NIXLBENCH_INSTALL_PREFIX}/bin/nixlbench /usr/local/bin/nixlbench'
+    )
+    if not _run_build_step(pod_name, env_setup, "environment setup", _out):
+        _out(f"    Warning: PATH setup failed. nixlbench may not be found via command -v.")
+
+    _out(f"  nixlbench built and installed at {NIXLBENCH_INSTALL_PREFIX} on {pod_name}.")
+    return True
+
+
+def build_nixlbench_from_source(pod_name, out=None):
+    """Full build pipeline: deps -> etcd-cpp-api -> NIXL -> nixlbench."""
+    _out = out or print
+    _out(f"  === Building nixlbench from source on {pod_name} ===")
+
+    # Ensure build directory exists
+    exec_in_pod(pod_name, ["mkdir", "-p", NIXL_BUILD_DIR], use_debug=False)
+
+    # Step 1: Install system and Python build dependencies
+    if not install_nixlbench_deps(pod_name, out=_out):
+        return False
+
+    # Step 2: Build etcd-cpp-apiv3 (optional but needed for multi-node)
+    etcd_ok = build_etcd_cpp_api(pod_name, out=_out)
+    if not etcd_ok:
+        _out(f"  Continuing without etcd-cpp-apiv3 (nixlbench etcd runtime will be disabled).")
+
+    # Step 3: Build NIXL library
+    if not build_nixl(pod_name, out=_out):
+        _out(f"  NIXL build failed. Cannot continue.")
+        return False
+
+    # Step 4: Build nixlbench binary
+    if not _build_nixlbench_binary(pod_name, out=_out):
+        _out(f"  nixlbench build failed.")
+        return False
+
+    _out(f"  === nixlbench build complete on {pod_name} ===")
+    return True
+
+
+def _check_etcd(pod_name):
+    """Check if etcd and etcdctl are available on a pod."""
+    return _check_binary(pod_name, "etcd") and _check_binary(pod_name, "etcdctl")
+
+
+def install_etcd(pod_name, out=None):
+    """Download and install etcd binary on a pod."""
+    _out = out or print
+    if _check_etcd(pod_name):
+        _out(f"  etcd already available on {pod_name}.")
+        return True
+
+    if not _get_common().INSTALL_DEPS:
+        _out(f"  Error: etcd not found on {pod_name}.")
+        _out(f"  Re-run with --install-deps to automatically install etcd.")
+        sys.exit(1)
+
+    _out(f"  Installing etcd {ETCD_VER} on {pod_name} ...")
+    install_script = (
+        f'curl -L {ETCD_DOWNLOAD_URL} -o /tmp/etcd.tar.gz'
+        f' && tar xzf /tmp/etcd.tar.gz -C /tmp'
+        f' && cp /tmp/etcd-{ETCD_VER}-linux-amd64/etcd /usr/local/bin/'
+        f' && cp /tmp/etcd-{ETCD_VER}-linux-amd64/etcdctl /usr/local/bin/'
+        f' && rm -rf /tmp/etcd*'
+        f' && echo "ETCD_INSTALLED"'
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", install_script], timeout=120, use_debug=False)
+    if result.returncode != 0 or "ETCD_INSTALLED" not in result.stdout:
+        _out(f"  Error: failed to install etcd: {result.stderr.strip()[:200]}")
+        return False
+    _out(f"  etcd {ETCD_VER} installed on {pod_name}.")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# ETCD lifecycle
+# ---------------------------------------------------------------------------
+def start_etcd_server(pod_name, pod_ip, out=None):
+    """Start etcd server in background on a pod. Returns Popen process."""
+    _out = out or print
+    _c = _get_common()
+
+    etcd_args = [
+        "etcd",
+        "--data-dir=/tmp/etcd-nixlbench-data",
+        f"--listen-client-urls=http://0.0.0.0:{ETCD_PORT}",
+        f"--advertise-client-urls=http://{pod_ip}:{ETCD_PORT}",
+        f"--listen-peer-urls=http://0.0.0.0:2380",
+        f"--initial-advertise-peer-urls=http://{pod_ip}:2380",
+        f"--initial-cluster=default=http://{pod_ip}:2380",
+    ]
+    cmd = _c._build_remote_cmd(pod_name, etcd_args)
+
+    _out(f"  Starting etcd server on {pod_name} ({pod_ip}:{ETCD_PORT}) ...")
+    if _c.VERBOSE:
+        _out(f"  $ {' '.join(cmd)}")
+
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _c._server_procs_append(proc)
+
+    # Wait for etcd to be ready
+    time.sleep(2)
+    health_result = exec_in_pod(
+        pod_name,
+        ["etcdctl", "endpoint", "health", f"--endpoints=http://localhost:{ETCD_PORT}"],
+        use_debug=False,
+    )
+    if health_result.returncode != 0:
+        _out(f"  Warning: etcd health check failed, waiting 3 more seconds ...")
+        time.sleep(3)
+
+    _out(f"  etcd server started on {pod_name}.")
+    return proc
+
+
+def stop_etcd_server(proc, out=None):
+    """Stop etcd server process."""
+    _out = out or print
+    try:
+        proc.terminate()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    _get_common()._server_procs_remove(proc)
+    _out("  etcd server stopped.")
+
+
+def cleanup_etcd_state(pod_name, etcd_endpoint, group=None, out=None):
+    """Clean up etcd state after a benchmark run."""
+    _out = out or print
+    prefix = f"xferbench/{group}" if group else "xferbench"
+    exec_in_pod(
+        pod_name,
+        ["etcdctl", "del", prefix, "--prefix=true", f"--endpoints={etcd_endpoint}"],
+        use_debug=False,
+    )
+    if _get_common().VERBOSE:
+        _out(f"  Cleaned etcd state: prefix={prefix}")
+
+
+# ---------------------------------------------------------------------------
+# NIXLBench execution
+# ---------------------------------------------------------------------------
+def _build_nixlbench_cmd(etcd_endpoint, benchmark_group):
+    """Build full shell command for nixlbench with proper PATH/LD_LIBRARY_PATH."""
+    # Convert buffer size to raw bytes (nixlbench expects uint64, not "8G")
+    buffer_bytes = _get_common()._parse_size(NIXLBENCH_BUFFER_SIZE)
+    nixl_args = (
+        f"--etcd_endpoints {etcd_endpoint} "
+        f"--benchmark_group {benchmark_group} "
+        f"--backend {NIXLBENCH_BACKEND} "
+        f"--initiator_seg_type {NIXLBENCH_SEG_TYPE} "
+        f"--target_seg_type {NIXLBENCH_SEG_TYPE} "
+        f"--op_type WRITE "
+        f"--total_buffer_size {buffer_bytes}"
+    )
+    # Wrap in bash to set PATH/LD_LIBRARY_PATH for built-from-source installs
+    # Include both lib64 (RHEL) and lib/<arch>-linux-gnu (Debian) paths
+    env_setup = (
+        f"export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:"
+        f"/usr/local/bin:$PATH && "
+        f"export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:"
+        f"{NIXLBENCH_INSTALL_PREFIX}/lib64:"
+        f"{NIXL_INSTALL_PREFIX}/lib64:"
+        f"{NIXL_INSTALL_PREFIX}/lib64/plugins:"
+        f"{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu:"
+        f"{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu/plugins:"
+        f"/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH"
+    )
+    return ["bash", "-c", f"{env_setup} && {NIXLBENCH_BINARY} {nixl_args}"]
+
+
+def run_nixlbench_pair(src_pod, src_ip, dst_pod, dst_ip, etcd_endpoint, group, out=None):
+    """Run nixlbench between two pods. Returns parsed metrics dict or None.
+
+    Launches target first (Popen), then initiator (subprocess.run blocking).
+    Both self-register via etcd to get ranks.
+    """
+    _out = out or print
+    _c = _get_common()
+
+    nixl_cmd_args = _build_nixlbench_cmd(etcd_endpoint, group)
+    short_desc = f"nixlbench --backend {NIXLBENCH_BACKEND} --benchmark_group {group}"
+
+    # Start target (background)
+    target_cmd = _c._build_remote_cmd(dst_pod, nixl_cmd_args)
+    _out(f"  Target: {short_desc}")
+    if _c.VERBOSE:
+        _out(f"  $ {' '.join(target_cmd)}")
+    target_proc = subprocess.Popen(target_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _c._server_procs_append(target_proc)
+
+    # Brief delay for target to register with etcd
+    time.sleep(2)
+
+    # Start initiator (blocking)
+    initiator_cmd = _c._build_remote_cmd(src_pod, nixl_cmd_args)
+    _out(f"  Initiator: {short_desc}")
+    if _c.VERBOSE:
+        _out(f"  $ {' '.join(initiator_cmd)}")
+
+    try:
+        result = subprocess.run(
+            initiator_cmd, capture_output=True, text=True, timeout=NIXLBENCH_TIMEOUT,
+        )
+    except subprocess.TimeoutExpired:
+        _out(f"    TIMEOUT after {NIXLBENCH_TIMEOUT}s")
+        result = None
+
+    # Clean up target and capture its output
+    try:
+        target_proc.terminate()
+    except OSError:
+        pass
+    try:
+        target_stdout, target_stderr = target_proc.communicate(timeout=10)
+    except (OSError, subprocess.TimeoutExpired):
+        target_stdout, target_stderr = b"", b""
+        try:
+            target_proc.kill()
+        except OSError:
+            pass
+    _c._server_procs_remove(target_proc)
+
+    if _c.VERBOSE and target_stdout:
+        target_out = target_stdout.decode("utf-8", errors="replace") if isinstance(target_stdout, bytes) else target_stdout
+        _out(f"  nixlbench target output ({len(target_out)} chars):\n{target_out[-2000:]}")
+
+    # Clean up etcd state for this group
+    cleanup_etcd_state(_etcd_pod_name, etcd_endpoint, group=group, out=_out)
+
+    if result is None or result.returncode != 0:
+        stderr_msg = result.stderr.strip()[:200] if result else "timeout"
+        _out(f"    FAILED: {stderr_msg}")
+        # Even if initiator fails, try parsing target output (it may have results)
+        if target_stdout:
+            target_text = target_stdout.decode("utf-8", errors="replace") if isinstance(target_stdout, bytes) else target_stdout
+            parsed = parse_nixlbench_output(target_text, out=_out)
+            if parsed:
+                return parsed
+        return None
+
+    # Try initiator output first, then target output
+    parsed = parse_nixlbench_output(result.stdout, out=_out)
+    if not parsed and target_stdout:
+        target_text = target_stdout.decode("utf-8", errors="replace") if isinstance(target_stdout, bytes) else target_stdout
+        parsed = parse_nixlbench_output(target_text, out=_out)
+    return parsed
+
+
+# Module-level state for etcd pod (set during run_nixlbench)
+_etcd_pod_name = None
+
+
+def parse_nixlbench_output(stdout, out=None):
+    """Parse nixlbench columnar output.
+
+    nixlbench outputs fixed-column tables.  Known column orders:
+      Short (8 cols): Block Size (B), Batch Size, B/W (GB/Sec), Avg Lat. (us),
+                      Avg Prep (us), P99 Prep (us), Avg Post (us), P99 Post (us)
+      Long (12 cols): adds Aggregate B/W (GB/Sec), Network Util (%),
+                      Avg Tx (us), P99 Tx (us)  after B/W
+
+    Data rows are whitespace-separated numbers.  The header row (multi-word
+    column names) is detected but NOT split — we use positional mapping
+    directly since the column order is fixed.
+
+    Returns dict with bw_gbs, lat_avg_us, lat_p99_us (prep) for the largest
+    block-size row, or None.
+    """
+    _out = out or print
+
+    if not stdout or not stdout.strip():
+        _out("    No output from nixlbench")
+        return None
+
+    if _get_common().VERBOSE:
+        _out(f"  nixlbench raw output ({len(stdout)} chars):\n{stdout[-3000:]}")
+
+    lines = stdout.strip().split("\n")
+
+    # Collect candidate data rows — lines where ALL tokens are numeric.
+    # Also note whether we see a header line (to confirm it's nixlbench output).
+    saw_header = False
+    data_rows = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        lower = stripped.lower()
+        if "block size" in lower or "b/w" in lower or "gb/sec" in lower:
+            saw_header = True
+            continue
+
+        # A data row: first char is a digit and all whitespace-separated
+        # tokens parse as floats.
+        if stripped[0].isdigit():
+            parts = stripped.split()
+            try:
+                vals = [float(p) for p in parts]
+                if len(vals) >= 3:  # need at least block_size, batch, bw
+                    data_rows.append(vals)
+            except ValueError:
+                pass
+
+    if not data_rows:
+        _out("    Warning: could not parse nixlbench output (no data rows)")
+        return None
+
+    # Use last data row (largest block size)
+    row = data_rows[-1]
+    ncols = len(row)
+    metrics = {}
+
+    # 10-col format (observed):
+    #   0=Block Size  1=Batch  2=B/W  3=Avg Lat  4=Avg Prep  5=P99 Prep
+    #   6=Avg Post  7=P99 Post  8=Avg Tx  9=P99 Tx
+    # 8-col format (short — no Avg Tx / P99 Tx):
+    #   0=Block Size  1=Batch  2=B/W  3=Avg Lat  4=Avg Prep  5=P99 Prep
+    #   6=Avg Post  7=P99 Post
+    # 12-col format (long — adds Aggregate B/W + Network Util after B/W):
+    #   0=Block Size 1=Batch 2=B/W 3=Agg B/W 4=Net Util 5=Avg Lat
+    #   6=Avg Prep 7=P99 Prep 8=Avg Post 9=P99 Post 10=Avg Tx 11=P99 Tx
+    if ncols >= 8 and ncols <= 10:
+        metrics["bw_gbs"] = row[2]
+        metrics["lat_avg_us"] = row[3]     # Avg Lat
+        metrics["lat_p99_us"] = row[7]     # P99 Post (completion/ack)
+    elif ncols >= 11:
+        metrics["bw_gbs"] = row[2]
+        metrics["lat_avg_us"] = row[5]     # Avg Lat
+        metrics["lat_p99_us"] = row[9]     # P99 Post
+    else:
+        metrics["bw_gbs"] = row[2] if ncols > 2 else row[-1]
+
+    if not saw_header and _get_common().VERBOSE:
+        _out(f"    Note: parsed {ncols}-column data row without header confirmation")
+
+    block_size = int(row[0]) if row[0] == int(row[0]) else row[0]
+    _out(f"    Parsed: block={block_size}  B/W={metrics.get('bw_gbs', '?')} GB/s"
+         f"  avg_lat={metrics.get('lat_avg_us', '?')} us"
+         f"  p99_lat={metrics.get('lat_p99_us', '?')} us")
+
+    return metrics
+
+
+def _run_nixlbench_matrix(pods, display_names, etcd_endpoint):
+    """Run nixlbench for all pod pairs. Returns dict of metric_name -> NxN matrix."""
+    _c = _get_common()
+    n = len(pods)
+    test_pairs = _c._cross_role_pairs(pods)
+    total_pairs = len(test_pairs)
+
+    print(f"\n{'─' * 50}")
+    print(f"  Running nixlbench — backend={NIXLBENCH_BACKEND} "
+          f"seg_type={NIXLBENCH_SEG_TYPE} buffer={NIXLBENCH_BUFFER_SIZE} "
+          f"— {total_pairs} pair(s)")
+    print(f"{'─' * 50}")
+
+    waves = _c._schedule_parallel_pairs(n, pairs=test_pairs)
+
+    # Metric matrices — populated as results come in
+    bw_matrix = [[None] * n for _ in range(n)]
+    lat_avg_matrix = [[None] * n for _ in range(n)]
+    lat_p99_matrix = [[None] * n for _ in range(n)]
+
+    done = 0
+
+    for wave_idx, wave in enumerate(waves):
+        pair_labels = ", ".join(
+            f"{display_names[pods[i][0]]}->{display_names[pods[j][0]]}"
+            for i, j in wave
+        )
+        print(f"\n  [wave {wave_idx + 1}/{len(waves)}] "
+              f"{len(wave)} pair(s) in parallel: {pair_labels}")
+
+        buffers = []
+        results_slot = [None] * len(wave)
+        done_events = [threading.Event() for _ in wave]
+
+        def _worker(slot, i, j, buf, done_evt):
+            try:
+                src_name, src_ip = pods[i]
+                dst_name, dst_ip = pods[j]
+                src_short = display_names[src_name]
+                dst_short = display_names[dst_name]
+
+                def _out(msg):
+                    buf.write(msg + "\n")
+
+                _out(f"\n    {src_short} -> {dst_short}")
+                group = f"pair_{i}_{j}"
+                pair_metrics = run_nixlbench_pair(
+                    src_name, src_ip, dst_name, dst_ip,
+                    etcd_endpoint, group, out=_out,
+                )
+                if pair_metrics:
+                    for k, v in pair_metrics.items():
+                        _out(f"    {k}: {v}")
+                else:
+                    _out(f"    FAIL")
+                results_slot[slot] = (i, j, pair_metrics)
+            except Exception as exc:
+                buf.write(f"\n    ERROR: {exc}\n")
+                results_slot[slot] = (i, j, None)
+            finally:
+                done_evt.set()
+
+        # Launch threads for this wave
+        threads = []
+        for slot, (i, j) in enumerate(wave):
+            buf = _c._StreamingBuffer()
+            buffers.append(buf)
+            t = threading.Thread(
+                target=_worker,
+                args=(slot, i, j, buf, done_events[slot]),
+                daemon=True,
+            )
+            threads.append(t)
+            t.start()
+
+        # Wait and flush output in pair order
+        for slot in range(len(wave)):
+            done_events[slot].wait()
+            buffers[slot].flush_all()
+
+        for t in threads:
+            t.join(timeout=5)
+
+        # Store results in matrices
+        for slot in range(len(wave)):
+            if results_slot[slot] is not None:
+                i, j, pair_metrics = results_slot[slot]
+                if pair_metrics:
+                    if "bw_gbs" in pair_metrics:
+                        bw_matrix[i][j] = pair_metrics["bw_gbs"]
+                    if "lat_avg_us" in pair_metrics:
+                        lat_avg_matrix[i][j] = pair_metrics["lat_avg_us"]
+                    if "lat_p99_us" in pair_metrics:
+                        lat_p99_matrix[i][j] = pair_metrics["lat_p99_us"]
+                done += 1
+
+    print(f"\n  Completed {done}/{total_pairs} pair(s)")
+
+    # Build results dict — only include metrics that have at least one value
+    results = {}
+    if any(bw_matrix[i][j] is not None for i in range(n) for j in range(n)):
+        results["NIXLBench Write BW (GB/s)"] = bw_matrix
+    if any(lat_avg_matrix[i][j] is not None for i in range(n) for j in range(n)):
+        results["NIXLBench Write Latency avg (usec)"] = lat_avg_matrix
+    if any(lat_p99_matrix[i][j] is not None for i in range(n) for j in range(n)):
+        results["NIXLBench Write Latency P99 (usec)"] = lat_p99_matrix
+
+    return results
+
+
+def run_nixlbench(pods, display_names):
+    """Run nixlbench between all pod pairs.
+
+    1. Verify nixlbench on all pods (parallel)
+    2. Install/verify etcd on pod 0
+    3. Start etcd on pod 0
+    4. Run nixlbench for all pairs
+    5. Stop etcd
+    """
+    global _etcd_pod_name
+    _c = _get_common()
+    n = len(pods)
+
+    print(f"\n{'=' * 60}")
+    print("  NIXLBENCH (NIXL Data Transfer Benchmark)")
+    print(f"{'=' * 60}")
+    print(f"Settings: backend={NIXLBENCH_BACKEND}, seg_type={NIXLBENCH_SEG_TYPE}, "
+          f"buffer_size={NIXLBENCH_BUFFER_SIZE}")
+
+    # --- Step 1: Verify nixlbench on all pods in parallel ---
+    print("\nEnsuring nixlbench is available on all pods (parallel) ...")
+    ensure_bufs = [_c._StreamingBuffer() for _ in range(n)]
+    ensure_done = [threading.Event() for _ in range(n)]
+
+    ensure_failed = [False] * n
+
+    def _ensure_worker(idx, pod_name, buf, done_evt):
+        try:
+            ensure_nixlbench(pod_name, out=lambda msg: buf.write(msg + "\n"))
+        except SystemExit:
+            buf.write(f"  FATAL: nixlbench not found on {pod_name}\n")
+            ensure_failed[idx] = True
+        except Exception as exc:
+            buf.write(f"  ERROR on {pod_name}: {exc}\n")
+            ensure_failed[idx] = True
+        finally:
+            done_evt.set()
+
+    ensure_threads = []
+    for idx, (name, _ip) in enumerate(pods):
+        t = threading.Thread(
+            target=_ensure_worker,
+            args=(idx, name, ensure_bufs[idx], ensure_done[idx]),
+            daemon=True,
+        )
+        ensure_threads.append(t)
+        t.start()
+
+    for idx in range(n):
+        while not ensure_done[idx].is_set():
+            ensure_bufs[idx].flush_new()
+            ensure_done[idx].wait(timeout=0.1)
+        ensure_bufs[idx].flush_all()
+
+    for t in ensure_threads:
+        t.join(timeout=5)
+
+    if any(ensure_failed):
+        failed_pods = [display_names[pods[i][0]] for i in range(n) if ensure_failed[i]]
+        print(f"\n  Aborting: nixlbench not available on {', '.join(failed_pods)}")
+        return {}
+
+    # --- Step 2: Install/verify etcd on pod 0 ---
+    etcd_pod_name, etcd_pod_ip = pods[0]
+    _etcd_pod_name = etcd_pod_name
+    print(f"\nSetting up etcd on {display_names[etcd_pod_name]} ...")
+    install_etcd(etcd_pod_name)
+
+    # --- Step 3: Start etcd server ---
+    etcd_proc = start_etcd_server(etcd_pod_name, etcd_pod_ip)
+    etcd_endpoint = f"http://{etcd_pod_ip}:{ETCD_PORT}"
+
+    try:
+        # --- Step 4: Run nixlbench matrix ---
+        results = _run_nixlbench_matrix(pods, display_names, etcd_endpoint)
+    finally:
+        # --- Step 5: Stop etcd ---
+        stop_etcd_server(etcd_proc)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point — allows:  uv run run-tests-nixlbench.py [options]
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    _USAGE = """\
+Usage: uv run run-tests-nixlbench.py [options]
+
+Run NIXLBench (NIXL data transfer benchmark) between Kubernetes inference pods.
+
+Equivalent to: run-tests.sh -t nixlbench
+
+Options:
+  --nixlbench-backend BACKEND
+                        NIXLBench backend (default: UCX).
+  --nixlbench-seg-type TYPE
+                        Segment type for initiator/target (default: VRAM).
+  --nixlbench-buffer-size SIZE
+                        Total buffer size (default: 8G).
+  -D, --debug-image IMAGE
+                        Use ephemeral debug containers with the given image.
+  -e, --explain         Show the kubectl/shell commands behind each finding.
+  -h, --help            Show this help message.
+  -i, --install-deps    Build nixlbench from source and install etcd
+                        if missing.  Requires CUDA and UCX in the pod image.
+  -l, --label SELECTOR  Label selector to discover pods
+                        (default: "llm-d.ai/inferenceServing=true").
+  -n, --namespace NS    Kubernetes namespace for all kubectl commands.
+  -v, --verbose         Print kubectl commands as they run.
+  -x, --explain-verify  Run each explain command and verify output.
+                        Implies --explain.
+"""
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print(_USAGE)
+        sys.exit(0)
+
+    _c = _get_common()
+    _cfg = _c._parse_common_args(extra_flags={
+        ("--nixlbench-backend",):       ("_NIXLBENCH_BACKEND", True),
+        ("--nixlbench-seg-type",):      ("_NIXLBENCH_SEG_TYPE", True),
+        ("--nixlbench-buffer-size",):   ("_NIXLBENCH_BUFFER_SIZE", True),
+    })
+
+    # Apply nixlbench-specific config
+    _raw_backend = _cfg.pop("_NIXLBENCH_BACKEND", None)
+    if _raw_backend:
+        NIXLBENCH_BACKEND = _raw_backend
+    _raw_seg = _cfg.pop("_NIXLBENCH_SEG_TYPE", None)
+    if _raw_seg:
+        NIXLBENCH_SEG_TYPE = _raw_seg
+    _raw_buf = _cfg.pop("_NIXLBENCH_BUFFER_SIZE", None)
+    if _raw_buf:
+        NIXLBENCH_BUFFER_SIZE = _raw_buf
+
+    _c.configure(**_cfg)
+
+    _pods, _display_names = _c._discover_and_display()
+    if _c.USE_DEBUG_CONTAINER:
+        print("\nCreating debug containers ...")
+        _c.create_debug_containers(_pods)
+
+    _results = run_nixlbench(_pods, _display_names)
+    # Print a simple summary
+    for _title, _matrix in _results.items():
+        print(f"\n{_title}:")
+        _header = [""] + [_display_names[p[0]] for p in _pods]
+        print("  " + "\t".join(_header))
+        for _i, (_name, _ip) in enumerate(_pods):
+            _row = [_display_names[_name]]
+            for _j in range(len(_pods)):
+                _val = _matrix[_i][_j]
+                _row.append(f"{_val:.2f}" if _val is not None else "-")
+            print("  " + "\t".join(_row))
+    _c.print_results_summary(_pods, _results, _display_names)

--- a/run-tests-nixlbench.py
+++ b/run-tests-nixlbench.py
@@ -64,6 +64,14 @@ ETCD_CPP_REPO = "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git"
 PROTOBUF_VER = "v21.12"
 GRPC_VER = "v1.46.7"
 
+# Non-root fallback paths (used when /usr/local is not writable)
+NONROOT_PREFIX = "/tmp/local"
+NONROOT_BIN = "/tmp/.local/bin"
+NONROOT_NIXL_PREFIX = "/tmp/local/nixl"
+NONROOT_NIXLBENCH_PREFIX = "/tmp/nixlbench"
+NIXL_PIP_LIBS = "/usr/local/lib/python3.12/dist-packages/.nixl_cu12.mesonpy.libs"
+NIXL_PIP_UCX_LIBS = "/usr/local/lib/python3.12/dist-packages/nixl_cu12.libs"
+
 # Defaults — overridden via configure() from run-tests.py
 NIXLBENCH_BACKEND = "UCX"
 NIXLBENCH_SEG_TYPE = "VRAM"
@@ -71,21 +79,79 @@ NIXLBENCH_BUFFER_SIZE = "8G"
 
 
 # ---------------------------------------------------------------------------
+# Non-root environment detection and helpers
+# ---------------------------------------------------------------------------
+_nonroot_cache = {}  # pod_name -> bool
+
+
+def _detect_nonroot(pod_name):
+    """Detect if a pod runs as non-root (cannot write to /usr/local/bin)."""
+    if pod_name in _nonroot_cache:
+        return _nonroot_cache[pod_name]
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         "touch /usr/local/bin/.test_write 2>/dev/null "
+         "&& rm -f /usr/local/bin/.test_write && echo ROOT || echo NONROOT"],
+        use_debug=False,
+    )
+    is_nonroot = "NONROOT" in (result.stdout or "")
+    _nonroot_cache[pod_name] = is_nonroot
+    return is_nonroot
+
+
+def _nonroot_env_prefix(pod_name):
+    """Build shell env prefix for non-root pods (HOME=/tmp, /tmp paths)."""
+    if not _detect_nonroot(pod_name):
+        return ""
+    return (
+        f'export HOME=/tmp && '
+        f'export PATH={NONROOT_BIN}:{NONROOT_NIXLBENCH_PREFIX}/bin:'
+        f'{NONROOT_NIXL_PREFIX}/bin:{NONROOT_PREFIX}/bin:$PATH && '
+        f'export LD_LIBRARY_PATH={NONROOT_NIXLBENCH_PREFIX}/lib:'
+        f'{NONROOT_NIXLBENCH_PREFIX}/lib64:'
+        f'{NONROOT_NIXL_PREFIX}/lib64:{NONROOT_NIXL_PREFIX}/lib64/plugins:'
+        f'{NONROOT_NIXL_PREFIX}/lib/$(uname -m)-linux-gnu:'
+        f'{NONROOT_NIXL_PREFIX}/lib/$(uname -m)-linux-gnu/plugins:'
+        f'{NONROOT_PREFIX}/lib64:{NONROOT_PREFIX}/lib:'
+        f'{NIXL_PIP_LIBS}:{NIXL_PIP_UCX_LIBS}:'
+        f'/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}} && '
+        f'export PKG_CONFIG_PATH={NONROOT_PREFIX}/lib64/pkgconfig:'
+        f'{NONROOT_PREFIX}/lib/pkgconfig:${{PKG_CONFIG_PATH:-}} && '
+    )
+
+
+def _get_install_prefix(pod_name):
+    """Return (nixl_prefix, nixlbench_prefix, local_prefix) based on root detection."""
+    if _detect_nonroot(pod_name):
+        return NONROOT_NIXL_PREFIX, NONROOT_NIXLBENCH_PREFIX, NONROOT_PREFIX
+    return NIXL_INSTALL_PREFIX, NIXLBENCH_INSTALL_PREFIX, "/usr/local"
+
+
+def _get_bin_dir(pod_name):
+    """Return the bin directory for installing standalone tools (etcd, git)."""
+    if _detect_nonroot(pod_name):
+        return NONROOT_BIN
+    return "/usr/local/bin"
+
+
+# ---------------------------------------------------------------------------
 # Binary checks
 # ---------------------------------------------------------------------------
 def _check_binary(pod_name, binary):
     """Check if a binary is available on a pod. Returns True if found."""
-    # Include nixlbench install paths in case it was built from source
-    # For nixlbench, also verify shared libraries can load (ldd check)
+    nixl_pfx, bench_pfx, _local_pfx = _get_install_prefix(pod_name)
+    nonroot_pfx = _nonroot_env_prefix(pod_name)
     env_prefix = (
-        f'export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:'
-        f'/usr/local/bin:$PATH && '
-        f'export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:'
-        f'{NIXLBENCH_INSTALL_PREFIX}/lib64:'
-        f'{NIXL_INSTALL_PREFIX}/lib64:'
-        f'{NIXL_INSTALL_PREFIX}/lib64/plugins:'
-        f'{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu:'
-        f'{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu/plugins:'
+        f'{nonroot_pfx}'
+        f'export PATH={bench_pfx}/bin:{nixl_pfx}/bin:'
+        f'{NONROOT_BIN}:/usr/local/bin:$PATH && '
+        f'export LD_LIBRARY_PATH={bench_pfx}/lib:'
+        f'{bench_pfx}/lib64:'
+        f'{nixl_pfx}/lib64:{nixl_pfx}/lib64/plugins:'
+        f'{nixl_pfx}/lib/$(uname -m)-linux-gnu:'
+        f'{nixl_pfx}/lib/$(uname -m)-linux-gnu/plugins:'
+        f'{NIXL_PIP_LIBS}:{NIXL_PIP_UCX_LIBS}:'
         f'/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}}'
     )
     if binary == NIXLBENCH_BINARY:
@@ -113,12 +179,16 @@ def _check_binary(pod_name, binary):
 
 def _check_etcd_runtime(pod_name):
     """Check if nixlbench was built with ETCD runtime support."""
+    nixl_pfx, bench_pfx, _local_pfx = _get_install_prefix(pod_name)
+    nonroot_pfx = _nonroot_env_prefix(pod_name)
     env_prefix = (
-        f'export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:'
-        f'/usr/local/bin:$PATH && '
-        f'export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:'
-        f'{NIXLBENCH_INSTALL_PREFIX}/lib64:'
-        f'{NIXL_INSTALL_PREFIX}/lib64:{NIXL_INSTALL_PREFIX}/lib64/plugins:'
+        f'{nonroot_pfx}'
+        f'export PATH={bench_pfx}/bin:{nixl_pfx}/bin:'
+        f'{NONROOT_BIN}:/usr/local/bin:$PATH && '
+        f'export LD_LIBRARY_PATH={bench_pfx}/lib:'
+        f'{bench_pfx}/lib64:'
+        f'{nixl_pfx}/lib64:{nixl_pfx}/lib64/plugins:'
+        f'{NIXL_PIP_LIBS}:{NIXL_PIP_UCX_LIBS}:'
         f'/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}}'
     )
     # Run nixlbench with --etcd_endpoints dummy to check if ETCD runtime is valid
@@ -138,16 +208,11 @@ def ensure_nixlbench(pod_name, out=None):
     """Verify nixlbench binary is available; build from source if --install-deps."""
     _out = out or print
     if _check_binary(pod_name, NIXLBENCH_BINARY):
-        # Also verify ETCD runtime is available
-        if _check_etcd_runtime(pod_name):
+        if _check_etcd_in_binary(pod_name):
             _out(f"  nixlbench binary available on {pod_name} (with ETCD runtime).")
-            return
-        elif _get_common().INSTALL_DEPS:
-            _out(f"  nixlbench found but lacks ETCD runtime on {pod_name}, rebuilding ...")
         else:
-            _out(f"  Warning: nixlbench on {pod_name} lacks ETCD runtime.")
-            _out(f"  Re-run with --install-deps (-i) to rebuild with ETCD support.")
-            sys.exit(1)
+            _out(f"  nixlbench binary available on {pod_name} (ASIO runtime, no ETCD).")
+        return
     if not _get_common().INSTALL_DEPS:
         _out(f"  Error: nixlbench binary not found on {pod_name}.")
         _out(f"  Re-run with --install-deps (-i) to build from source,")
@@ -171,11 +236,12 @@ def _run_build_step(pod_name, cmd, label, out, timeout=600, ignore_error=False):
     """Run a build step inside the pod. Returns True on success."""
     _out = out or print
     _out(f"    [{label}] ...")
-    # Ensure /usr/local/bin is on PATH (pip installs meson/ninja there)
-    # Also set PKG_CONFIG_PATH for locally-built libraries
+    nonroot_pfx = _nonroot_env_prefix(pod_name)
+    _nixl_pfx, _bench_pfx, local_pfx = _get_install_prefix(pod_name)
     cmd_with_path = (
-        f'export PATH=/usr/local/bin:$PATH && '
-        f'export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:${{PKG_CONFIG_PATH:-}} && '
+        f'{nonroot_pfx}'
+        f'export PATH={NONROOT_BIN}:/usr/local/bin:$PATH && '
+        f'export PKG_CONFIG_PATH={local_pfx}/lib64/pkgconfig:{local_pfx}/lib/pkgconfig:${{PKG_CONFIG_PATH:-}} && '
         f'{cmd}'
     )
     result = exec_in_pod(pod_name, ["bash", "-c", cmd_with_path], timeout=timeout, use_debug=False)
@@ -193,15 +259,85 @@ def _run_build_step(pod_name, cmd, label, out, timeout=600, ignore_error=False):
     return True
 
 
+def _install_deps_nonroot(pod_name, out=None):
+    """Install build dependencies for non-root pods using pip and curl."""
+    _out = out or print
+    _out(f"  Detected non-root environment on {pod_name}")
+    _out(f"  Installing build tools via pip to /tmp/.local/bin ...")
+
+    # Python build tools via HOME=/tmp pip install --user
+    pip_pkgs = "meson pybind11 tomlkit cmake pkgconf"
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         f"export HOME=/tmp && "
+         f"pip install --user {pip_pkgs} 2>&1 || "
+         f"pip3 install --user {pip_pkgs} 2>&1 || "
+         f"python3 -m pip install --user {pip_pkgs} 2>&1"],
+        timeout=180, use_debug=False,
+    )
+    if result.returncode != 0:
+        _out(f"    Warning: pip install failed: {(result.stderr or result.stdout or '').strip()[:300]}")
+    else:
+        _out(f"    Installed Python build tools (meson, cmake, pybind11).")
+
+    # Verify pkg-config is available (installed via pkgconf above)
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         f"export HOME=/tmp && export PATH={NONROOT_BIN}:$PATH && "
+         f"command -v pkg-config >/dev/null 2>&1 && echo OK || echo MISSING"],
+        timeout=30, use_debug=False,
+    )
+    if "OK" in (result.stdout or ""):
+        _out(f"    pkg-config available at {NONROOT_BIN}/pkg-config")
+    else:
+        _out(f"    Warning: pkg-config not found on PATH")
+
+    # Check for git — download static binary if missing
+    git_check = exec_in_pod(
+        pod_name,
+        ["bash", "-c", f"export PATH={NONROOT_BIN}:$PATH && command -v git"],
+        use_debug=False,
+    )
+    if git_check.returncode != 0:
+        _out(f"    git not found; will use curl for tarball downloads.")
+
+    # Ensure /tmp/.local/bin and build dirs exist
+    exec_in_pod(
+        pod_name,
+        ["bash", "-c", f"mkdir -p {NONROOT_BIN} {NONROOT_PREFIX} {NIXL_BUILD_DIR}"],
+        use_debug=False,
+    )
+
+    # Verify essential tools
+    verify_cmd = (
+        f"export HOME=/tmp && export PATH={NONROOT_BIN}:/usr/local/bin:$PATH && "
+        f"echo 'meson:' $(meson --version 2>/dev/null || echo MISSING) && "
+        f"echo 'cmake:' $(cmake --version 2>/dev/null | head -1 || echo MISSING) && "
+        f"echo 'ninja:' $(ninja --version 2>/dev/null || echo MISSING) && "
+        f"echo 'gcc:' $(gcc --version 2>/dev/null | head -1 || echo MISSING)"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", verify_cmd], use_debug=False)
+    if result.stdout:
+        for line in result.stdout.strip().split("\n"):
+            _out(f"    {line}")
+
+    _out(f"  Build dependencies ready on {pod_name}.")
+    return True
+
+
 def install_nixlbench_deps(pod_name, out=None):
     """Install system packages and Python build tools needed for nixlbench."""
     _out = out or print
     _out(f"  Installing build dependencies on {pod_name} ...")
 
+    # Non-root path: skip apt-get/dnf entirely, use pip + curl
+    if _detect_nonroot(pod_name):
+        return _install_deps_nonroot(pod_name, out=_out)
+
     # Package groups by distro family — installed one group at a time so a
     # failure in one doesn't block the rest.
-    # Install each package individually to avoid one missing package
-    # blocking the rest.  RHEL 9 UBI repos have limited -devel packages.
     rpm_groups = [
         ("gcc gcc-c++ ninja-build cmake pkgconfig git python3-pip",
          "core build tools"),
@@ -307,30 +443,66 @@ def _clean_build_dir(pod_name, build_dir, out):
     )
 
 
+def _clone_or_download(pod_name, repo_url, branch_or_tag, dest_dir, out):
+    """Clone a git repo, or fall back to curl tarball download if git is unavailable."""
+    _out = out or print
+    # In non-root mode we install a git stub (for meson version queries only),
+    # so always use curl for actual cloning in that case.
+    use_git = False
+    if not _detect_nonroot(pod_name):
+        git_check = exec_in_pod(
+            pod_name,
+            ["bash", "-c", f"export PATH={NONROOT_BIN}:$PATH && "
+             f"git --version 2>/dev/null | grep -q 'git version'"],
+            use_debug=False,
+        )
+        use_git = git_check.returncode == 0
+    if use_git:
+        return f"git clone --depth 1 --branch {branch_or_tag} {repo_url} {dest_dir}"
+    # Fallback: download tarball via curl (try tag first, then branch)
+    base_url = repo_url.replace(".git", "")
+    return (
+        f"mkdir -p {dest_dir} && "
+        f"(curl -sfL {base_url}/archive/refs/tags/{branch_or_tag}.tar.gz -o /tmp/_dl.tar.gz "
+        f"|| curl -sfL {base_url}/archive/refs/heads/{branch_or_tag}.tar.gz -o /tmp/_dl.tar.gz "
+        f"|| curl -sfL {base_url}/archive/{branch_or_tag}.tar.gz -o /tmp/_dl.tar.gz) && "
+        f"tar xzf /tmp/_dl.tar.gz --strip-components=1 -C {dest_dir} && "
+        f"rm -f /tmp/_dl.tar.gz"
+    )
+
+
 def build_protobuf(pod_name, out=None):
     """Build protobuf from source (required by gRPC and etcd-cpp-apiv3)."""
     _out = out or print
+    _nixl_pfx, _bench_pfx, local_pfx = _get_install_prefix(pod_name)
+    nonroot = _detect_nonroot(pod_name)
     if _check_lib_installed(pod_name, "protobuf",
-                            ["/usr/local/lib64/libprotobuf.so",
+                            [f"{local_pfx}/lib64/libprotobuf.so",
+                             f"{local_pfx}/lib/libprotobuf.so",
+                             "/usr/local/lib64/libprotobuf.so",
                              "/usr/local/lib/libprotobuf.so"]):
         _out(f"    protobuf already installed.")
         return True
     _out(f"  Building protobuf on {pod_name} ...")
     build_dir = f"{NIXL_BUILD_DIR}/protobuf"
     _clean_build_dir(pod_name, build_dir, _out)
+    clone_cmd = _clone_or_download(
+        pod_name, "https://github.com/protocolbuffers/protobuf.git",
+        PROTOBUF_VER, build_dir, _out)
+    install_cmd = f"cd {build_dir}/build && make install"
+    if not nonroot:
+        install_cmd += " && ldconfig"
     steps = [
-        (f"git clone --depth 1 --branch {PROTOBUF_VER} "
-         f"https://github.com/protocolbuffers/protobuf.git {build_dir}",
-         "clone protobuf", 120),
-        (f"cd {build_dir} && git submodule update --init --recursive",
+        (clone_cmd, "clone protobuf", 120),
+        (f"cd {build_dir} && git submodule update --init --recursive 2>/dev/null || true",
          "init submodules", 120),
         (f"mkdir -p {build_dir}/build && cd {build_dir}/build && "
-         f"cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local "
+         f"cmake .. -DCMAKE_INSTALL_PREFIX={local_pfx} "
          f"-DCMAKE_POSITION_INDEPENDENT_CODE=ON "
          f"-Dprotobuf_BUILD_TESTS=OFF -DBUILD_SHARED_LIBS=ON",
          "cmake configure", 120),
         (f"cd {build_dir}/build && make -j$(nproc)", "build", 600),
-        (f"cd {build_dir}/build && make install && ldconfig", "install", 120),
+        (install_cmd, "install", 120),
     ]
     for cmd, label, t in steps:
         if not _run_build_step(pod_name, cmd, label, _out, timeout=t):
@@ -343,24 +515,31 @@ def build_protobuf(pod_name, out=None):
 def build_grpc(pod_name, out=None):
     """Build gRPC from source with bundled abseil (required by etcd-cpp-apiv3)."""
     _out = out or print
+    _nixl_pfx, _bench_pfx, local_pfx = _get_install_prefix(pod_name)
+    nonroot = _detect_nonroot(pod_name)
     if _check_lib_installed(pod_name, "grpc++",
-                            ["/usr/local/lib/libgrpc++.so",
+                            [f"{local_pfx}/lib/libgrpc++.so",
+                             f"{local_pfx}/lib64/libgrpc++.so",
+                             "/usr/local/lib/libgrpc++.so",
                              "/usr/local/lib64/libgrpc++.so"]):
         _out(f"    gRPC already installed.")
         return True
     _out(f"  Building gRPC on {pod_name} (this may take several minutes) ...")
     build_dir = f"{NIXL_BUILD_DIR}/grpc"
     _clean_build_dir(pod_name, build_dir, _out)
+    clone_cmd = _clone_or_download(
+        pod_name, "https://github.com/grpc/grpc.git",
+        GRPC_VER, build_dir, _out)
+    install_cmd = f"cd {build_dir}/build && cmake --install ."
+    if not nonroot:
+        install_cmd += " && ldconfig"
     steps = [
-        (f"git clone --depth 1 --branch {GRPC_VER} "
-         f"https://github.com/grpc/grpc.git {build_dir}",
-         "clone gRPC", 120),
-        # Init only needed submodules: abseil and c-ares
+        (clone_cmd, "clone gRPC", 120),
         (f"cd {build_dir} && git submodule update --init "
-         f"third_party/abseil-cpp third_party/cares/cares",
+         f"third_party/abseil-cpp third_party/cares/cares 2>/dev/null || true",
          "init submodules", 120),
         (f"mkdir -p {build_dir}/build && cd {build_dir}/build && "
-         f"cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local "
+         f"cmake .. -DCMAKE_INSTALL_PREFIX={local_pfx} "
          f"-DBUILD_SHARED_LIBS=ON -DgRPC_INSTALL=ON "
          f"-DgRPC_BUILD_TESTS=OFF "
          f"-DgRPC_PROTOBUF_PROVIDER=package "
@@ -372,12 +551,9 @@ def build_grpc(pod_name, out=None):
          f"-DCMAKE_POSITION_INDEPENDENT_CODE=ON",
          "cmake configure", 120),
         (f"cd {build_dir}/build && make -j$(nproc)", "build", 900),
-        (f"cd {build_dir}/build && cmake --install . && ldconfig", "install", 120),
-        # Remove gRPC's bundled abseil pkg-config files so they don't conflict
-        # with NIXL's meson subproject abseil (which is much newer).
-        # gRPC itself links abseil statically via its module provider.
-        (f"rm -f /usr/local/lib/pkgconfig/absl_*.pc "
-         f"/usr/local/lib64/pkgconfig/absl_*.pc 2>/dev/null; "
+        (install_cmd, "install", 120),
+        (f"rm -f {local_pfx}/lib/pkgconfig/absl_*.pc "
+         f"{local_pfx}/lib64/pkgconfig/absl_*.pc 2>/dev/null; "
          f"dnf remove -y abseil-cpp abseil-cpp-devel 2>/dev/null; true",
          "clean abseil pkg-config", 60),
     ]
@@ -396,10 +572,14 @@ def build_etcd_cpp_api(pod_name, out=None):
     if not already present (RHEL 9 UBI repos lack these C++ packages).
     """
     _out = out or print
+    _nixl_pfx, _bench_pfx, local_pfx = _get_install_prefix(pod_name)
+    nonroot = _detect_nonroot(pod_name)
 
     # Check if already installed
     if _check_lib_installed(pod_name, "etcd-cpp-api",
-                            ["/usr/local/lib64/libetcd-cpp-api-core.so",
+                            [f"{local_pfx}/lib64/libetcd-cpp-api-core.so",
+                             f"{local_pfx}/lib/libetcd-cpp-api-core.so",
+                             "/usr/local/lib64/libetcd-cpp-api-core.so",
                              "/usr/local/lib/libetcd-cpp-api-core.so"]):
         _out(f"    etcd-cpp-apiv3 already available.")
         return True
@@ -420,16 +600,21 @@ def build_etcd_cpp_api(pod_name, out=None):
     _out(f"  Building etcd-cpp-apiv3 on {pod_name} ...")
     build_dir = f"{NIXL_BUILD_DIR}/etcd-cpp-apiv3"
     _clean_build_dir(pod_name, build_dir, _out)
+    clone_cmd = _clone_or_download(
+        pod_name, "https://github.com/etcd-cpp-apiv3/etcd-cpp-apiv3.git",
+        "master", build_dir, _out)
+    install_cmd = f"cd {build_dir}/build && make install"
+    if not nonroot:
+        install_cmd += " && ldconfig"
     steps = [
-        (f"git clone --depth 1 {ETCD_CPP_REPO} {build_dir}",
-         "clone etcd-cpp-apiv3", 120),
+        (clone_cmd, "clone etcd-cpp-apiv3", 120),
         (f"mkdir -p {build_dir}/build && cd {build_dir}/build && "
-         f"cmake .. -DCMAKE_INSTALL_PREFIX=/usr/local -DBUILD_SHARED_LIBS=ON "
+         f"cmake .. -DCMAKE_INSTALL_PREFIX={local_pfx} -DBUILD_SHARED_LIBS=ON "
          f"-DBUILD_ETCD_TESTS=OFF -DBUILD_ETCD_CORE_ONLY=ON "
-         f"-DCMAKE_PREFIX_PATH=/usr/local",
+         f"-DCMAKE_PREFIX_PATH={local_pfx}",
          "cmake configure", 120),
         (f"cd {build_dir}/build && make -j$(nproc)", "build", 300),
-        (f"cd {build_dir}/build && make install && ldconfig", "install", 120),
+        (install_cmd, "install", 120),
     ]
     for cmd, label, t in steps:
         if not _run_build_step(pod_name, cmd, label, _out, timeout=t):
@@ -439,9 +624,9 @@ def build_etcd_cpp_api(pod_name, out=None):
 
     # Create pkg-config file (meson needs it to find etcd-cpp-api)
     pkgconfig_cmd = (
-        'mkdir -p /usr/local/lib64/pkgconfig && '
-        'cat > /usr/local/lib64/pkgconfig/etcd-cpp-api.pc << "PKGEOF"\n'
-        'prefix=/usr/local\n'
+        f'mkdir -p {local_pfx}/lib64/pkgconfig && '
+        f'cat > {local_pfx}/lib64/pkgconfig/etcd-cpp-api.pc << "PKGEOF"\n'
+        f'prefix={local_pfx}\n'
         'exec_prefix=${prefix}\n'
         'libdir=${prefix}/lib64\n'
         'includedir=${prefix}/include\n'
@@ -459,10 +644,73 @@ def build_etcd_cpp_api(pod_name, out=None):
     return True
 
 
+def _setup_ucx_prefix_from_pip(pod_name, out=None):
+    """Create a proper UCX prefix from pip package libs + downloaded headers.
+
+    The pip nixl_cu12 package bundles UCX runtime libs with versioned names.
+    This function creates a standard UCX prefix layout at NONROOT_PREFIX/ucx with:
+    - lib/libucp.so etc (symlinks to pip versioned libs)
+    - lib/ucx/ (symlink to pip ucx plugins dir)
+    - include/ucp/, include/ucs/, include/uct/ (downloaded from UCX release)
+    """
+    _out = out or print
+    ucx_pfx = f"{NONROOT_PREFIX}/ucx"
+    pip_ucx = NIXL_PIP_UCX_LIBS
+
+    # Create lib symlinks (versioned -> unversioned)
+    setup_cmd = (
+        f"mkdir -p {ucx_pfx}/lib {ucx_pfx}/include && "
+        f"for f in {pip_ucx}/libucp-*.so*; do ln -sf \"$f\" {ucx_pfx}/lib/libucp.so; done && "
+        f"for f in {pip_ucx}/libucs-*.so*; do ln -sf \"$f\" {ucx_pfx}/lib/libucs.so; done && "
+        f"for f in {pip_ucx}/libuct-*.so*; do ln -sf \"$f\" {ucx_pfx}/lib/libuct.so; done && "
+        f"for f in {pip_ucx}/libucm-*.so*; do ln -sf \"$f\" {ucx_pfx}/lib/libucm.so; done && "
+        f"ln -sfn {pip_ucx}/ucx {ucx_pfx}/lib/ucx && "
+        f"echo LIBS_OK"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", setup_cmd], timeout=30, use_debug=False)
+    if "LIBS_OK" not in (result.stdout or ""):
+        _out(f"    Warning: failed to create UCX lib symlinks")
+        return None
+
+    # Download UCX headers from release tarball (just the src/ucp, src/ucs, src/uct include dirs)
+    # UCX 1.18.0 matches the bundled version (check via lib version)
+    headers_cmd = (
+        f"if [ ! -f {ucx_pfx}/include/ucp/api/ucp.h ]; then "
+        f"  curl -sfL https://github.com/openucx/ucx/releases/download/v1.18.0/ucx-1.18.0.tar.gz "
+        f"  -o /tmp/_ucx_headers.tar.gz && "
+        f"  tar xzf /tmp/_ucx_headers.tar.gz -C /tmp "
+        f"  ucx-1.18.0/src/ucp/api ucx-1.18.0/src/ucs/type "
+        f"  ucx-1.18.0/src/ucs/sys ucx-1.18.0/src/ucs/memory "
+        f"  ucx-1.18.0/src/ucs/config ucx-1.18.0/src/uct/api 2>/dev/null && "
+        f"  mkdir -p {ucx_pfx}/include/ucp/api {ucx_pfx}/include/ucs/type "
+        f"  {ucx_pfx}/include/ucs/sys {ucx_pfx}/include/ucs/memory "
+        f"  {ucx_pfx}/include/ucs/config {ucx_pfx}/include/uct/api && "
+        f"  cp /tmp/ucx-1.18.0/src/ucp/api/*.h {ucx_pfx}/include/ucp/api/ && "
+        f"  cp /tmp/ucx-1.18.0/src/ucs/type/*.h {ucx_pfx}/include/ucs/type/ && "
+        f"  cp /tmp/ucx-1.18.0/src/ucs/sys/*.h {ucx_pfx}/include/ucs/sys/ && "
+        f"  cp /tmp/ucx-1.18.0/src/ucs/memory/*.h {ucx_pfx}/include/ucs/memory/ && "
+        f"  cp /tmp/ucx-1.18.0/src/ucs/config/*.h {ucx_pfx}/include/ucs/config/ && "
+        f"  cp /tmp/ucx-1.18.0/src/uct/api/*.h {ucx_pfx}/include/uct/api/ && "
+        f"  rm -rf /tmp/ucx-1.18.0 /tmp/_ucx_headers.tar.gz && "
+        f"  echo HEADERS_OK; "
+        f"else echo HEADERS_OK; fi"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", headers_cmd], timeout=120, use_debug=False)
+    if "HEADERS_OK" not in (result.stdout or ""):
+        _out(f"    Warning: failed to download UCX headers")
+        return None
+
+    _out(f"    UCX prefix set up at {ucx_pfx} (headers downloaded, libs from pip)")
+    return ucx_pfx
+
+
 def _detect_ucx_path(pod_name):
     """Detect UCX installation path on the pod."""
-    # Check common locations: /opt/ucx, /usr/local, /usr
-    for path in ["/opt/ucx", "/usr/local", "/usr"]:
+    # Check common locations including pip package bundled UCX
+    search_paths = ["/opt/ucx", "/usr/local", "/usr"]
+    if _detect_nonroot(pod_name):
+        search_paths = [f"{NONROOT_PREFIX}/ucx"] + search_paths
+    for path in search_paths:
         result = exec_in_pod(
             pod_name,
             ["bash", "-c", f"test -f {path}/lib/libucp.so && echo FOUND"],
@@ -470,16 +718,29 @@ def _detect_ucx_path(pod_name):
         )
         if result.returncode == 0 and "FOUND" in result.stdout:
             return path
+    # Check for UCX bundled in the NIXL pip package (versioned .so names)
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", f"ls {NIXL_PIP_UCX_LIBS}/libucp-*.so* 2>/dev/null && echo FOUND"],
+        use_debug=False,
+    )
+    if result.returncode == 0 and "FOUND" in result.stdout:
+        return NIXL_PIP_UCX_LIBS
     return None
 
 
 def build_nixl(pod_name, out=None):
     """Clone and build NIXL library from source (UCX plugin only)."""
     _out = out or print
+    nixl_pfx, _bench_pfx, local_pfx = _get_install_prefix(pod_name)
+    nonroot = _detect_nonroot(pod_name)
     _out(f"  Building NIXL library on {pod_name} ...")
 
     # Detect UCX path for meson
     ucx_path = _detect_ucx_path(pod_name)
+    if ucx_path == NIXL_PIP_UCX_LIBS and nonroot:
+        # pip UCX has versioned .so names and no headers — create a proper prefix
+        ucx_path = _setup_ucx_prefix_from_pip(pod_name, out=_out)
     if ucx_path:
         _out(f"    Found UCX at {ucx_path}")
     else:
@@ -487,7 +748,7 @@ def build_nixl(pod_name, out=None):
 
     nixl_src = f"{NIXL_BUILD_DIR}/nixl"
     meson_args = (
-        f"--prefix={NIXL_INSTALL_PREFIX} --buildtype=release "
+        f"--prefix={nixl_pfx} --buildtype=release "
         f"-Denable_plugins=UCX -Dinstall_headers=true"
     )
     if ucx_path and ucx_path not in ("/usr", "/usr/local"):
@@ -499,10 +760,12 @@ def build_nixl(pod_name, out=None):
         f"chmod -R u+rwx {nixl_src} 2>/dev/null; rm -rf {nixl_src}",
         "clean", _out, timeout=60, ignore_error=True,
     )
+    clone_cmd = _clone_or_download(
+        pod_name, NIXL_REPO, "main", nixl_src, _out)
     steps = [
-        (f"git clone --depth 1 {NIXL_REPO} {nixl_src}", "clone NIXL", 300),
+        (clone_cmd, "clone NIXL", 300),
         (f"cd {nixl_src} && meson setup build {meson_args}",
-         "meson configure", 900),  # downloads abseil subproject
+         "meson configure", 900),
         (f"cd {nixl_src}/build && ninja", "build", 900),
         (f"cd {nixl_src}/build && ninja install", "install", 120),
     ]
@@ -510,52 +773,83 @@ def build_nixl(pod_name, out=None):
         if not _run_build_step(pod_name, cmd, label, _out, timeout=step_timeout):
             return False
 
-    # Configure linker to find NIXL libraries.
-    # Detect actual lib dir: RHEL uses lib64, Debian uses lib/<arch>-linux-gnu
-    ldconfig_cmd = (
-        f'NIXL_LIBDIR=$(find {NIXL_INSTALL_PREFIX} -maxdepth 1 -name "lib*" -type d | head -1) && '
-        f'echo "$NIXL_LIBDIR" > /etc/ld.so.conf.d/nixl.conf && '
-        f'[ -d "$NIXL_LIBDIR/plugins" ] && echo "$NIXL_LIBDIR/plugins" >> /etc/ld.so.conf.d/nixl.conf; '
-        f'ldconfig'
-    )
-    if not _run_build_step(pod_name, ldconfig_cmd, "ldconfig", _out):
-        _out(f"    Warning: ldconfig failed, may need LD_LIBRARY_PATH at runtime.")
+    if not nonroot:
+        # Configure linker to find NIXL libraries (root only)
+        ldconfig_cmd = (
+            f'NIXL_LIBDIR=$(find {nixl_pfx} -maxdepth 1 -name "lib*" -type d | head -1) && '
+            f'echo "$NIXL_LIBDIR" > /etc/ld.so.conf.d/nixl.conf && '
+            f'[ -d "$NIXL_LIBDIR/plugins" ] && echo "$NIXL_LIBDIR/plugins" >> /etc/ld.so.conf.d/nixl.conf; '
+            f'ldconfig'
+        )
+        if not _run_build_step(pod_name, ldconfig_cmd, "ldconfig", _out):
+            _out(f"    Warning: ldconfig failed, may need LD_LIBRARY_PATH at runtime.")
 
-    # Also create symlinks in /usr/local/lib64 (RHEL) or /usr/local/lib as
-    # fallback — ensures the runtime linker finds libs even without ldconfig
-    symlink_cmd = (
-        f'NIXL_LIBDIR=$(find {NIXL_INSTALL_PREFIX} -maxdepth 1 -name "lib*" -type d | head -1) && '
-        f'SYSLIB=$([ -d /usr/local/lib64 ] && echo /usr/local/lib64 || echo /usr/local/lib) && '
-        f'mkdir -p $SYSLIB && '
-        f'for f in $NIXL_LIBDIR/lib*.so*; do '
-        f'  [ -f "$f" ] && ln -sf "$f" $SYSLIB/$(basename "$f") || true; '
-        f'done; '
-        f'for f in $NIXL_LIBDIR/plugins/lib*.so*; do '
-        f'  [ -f "$f" ] && ln -sf "$f" $SYSLIB/$(basename "$f") || true; '
-        f'done; ldconfig'
-    )
-    if not _run_build_step(pod_name, symlink_cmd, "library symlinks", _out):
-        _out(f"    Warning: symlink creation failed.")
+        symlink_cmd = (
+            f'NIXL_LIBDIR=$(find {nixl_pfx} -maxdepth 1 -name "lib*" -type d | head -1) && '
+            f'SYSLIB=$([ -d /usr/local/lib64 ] && echo /usr/local/lib64 || echo /usr/local/lib) && '
+            f'mkdir -p $SYSLIB && '
+            f'for f in $NIXL_LIBDIR/lib*.so*; do '
+            f'  [ -f "$f" ] && ln -sf "$f" $SYSLIB/$(basename "$f") || true; '
+            f'done; '
+            f'for f in $NIXL_LIBDIR/plugins/lib*.so*; do '
+            f'  [ -f "$f" ] && ln -sf "$f" $SYSLIB/$(basename "$f") || true; '
+            f'done; ldconfig'
+        )
+        if not _run_build_step(pod_name, symlink_cmd, "library symlinks", _out):
+            _out(f"    Warning: symlink creation failed.")
+    else:
+        _out(f"    Non-root: skipping ldconfig/symlinks (using LD_LIBRARY_PATH)")
+        # Create lib64 symlink for nixlbench (meson uses libdir=lib64 for find_library)
+        _run_build_step(
+            pod_name,
+            f"rm -rf {nixl_pfx}/lib64 && "
+            f"NIXL_LIBDIR=$(find {nixl_pfx}/lib -maxdepth 2 -name 'libnixl.so' -exec dirname {{}} \\; | head -1) && "
+            f"[ -n \"$NIXL_LIBDIR\" ] && ln -sf \"$NIXL_LIBDIR\" {nixl_pfx}/lib64",
+            "create lib64 symlink", _out, timeout=10, ignore_error=True,
+        )
 
-    _out(f"  NIXL built and installed at {NIXL_INSTALL_PREFIX} on {pod_name}.")
+    _out(f"  NIXL built and installed at {nixl_pfx} on {pod_name}.")
     return True
 
 
 def _build_nixlbench_binary(pod_name, out=None):
     """Build nixlbench binary against installed NIXL."""
     _out = out or print
+    nixl_pfx, bench_pfx, local_pfx = _get_install_prefix(pod_name)
+    nonroot = _detect_nonroot(pod_name)
     _out(f"  Building nixlbench on {pod_name} ...")
 
     nixlbench_src = f"{NIXL_BUILD_DIR}/nixl/benchmark/nixlbench"
-    # Set PKG_CONFIG_PATH so meson finds etcd-cpp-api and other locally-built libs
-    pkg_env = "export PKG_CONFIG_PATH=/usr/local/lib64/pkgconfig:/usr/local/lib/pkgconfig:$PKG_CONFIG_PATH"
+    pkg_env = f"export PKG_CONFIG_PATH={local_pfx}/lib64/pkgconfig:{local_pfx}/lib/pkgconfig:$PKG_CONFIG_PATH"
     meson_args = (
-        f"-Dnixl_path={NIXL_INSTALL_PREFIX}/ "
-        f"-Dprefix={NIXLBENCH_INSTALL_PREFIX} "
-        f"-Detcd_inc_path=/usr/local/include "
-        f"-Detcd_lib_path=/usr/local/lib64 "
+        f"-Dnixl_path={nixl_pfx}/ "
+        f"-Dprefix={bench_pfx} "
+        f"-Dlibdir=lib64 "
+        f"-Detcd_inc_path={local_pfx}/include "
+        f"-Detcd_lib_path={local_pfx}/lib64 "
         f"--buildtype=release"
     )
+
+    # Ensure gflags wrap is available (needed for non-root where system libgflags-dev is missing)
+    if nonroot:
+        _run_build_step(
+            pod_name,
+            f"cd {nixlbench_src} && "
+            f"(test -f subprojects/gflags.wrap || meson wrap install gflags)",
+            "install gflags wrap", _out, timeout=60, ignore_error=True,
+        )
+        # Create etcd include/lib dirs even when empty (meson.build references them unconditionally)
+        exec_in_pod(pod_name, ["bash", "-c", f"mkdir -p {local_pfx}/include {local_pfx}/lib64"], use_debug=False)
+
+    # Patch worker meson.build to add asio_dep (upstream bug: worker includes asio_runtime.h
+    # which needs asio.hpp but asio_dep is not in worker_deps)
+    _run_build_step(
+        pod_name,
+        f"cd {nixlbench_src} && "
+        f"sed -i 's/tomlplusplus_dep$/tomlplusplus_dep,\\n  asio_dep/' src/worker/meson.build",
+        "patch worker deps", _out, timeout=30, ignore_error=True,
+    )
+
     steps = [
         (f"{pkg_env} && cd {nixlbench_src} && meson setup build {meson_args}",
          "meson configure", 300),
@@ -566,25 +860,93 @@ def _build_nixlbench_binary(pod_name, out=None):
         if not _run_build_step(pod_name, cmd, label, _out, timeout=step_timeout):
             return False
 
-    # Add to PATH and LD_LIBRARY_PATH via profile.d for this session
-    env_setup = (
-        f'echo "export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:\\$PATH" '
-        f'> /etc/profile.d/nixlbench.sh && '
-        f'echo "export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:'
-        f'{NIXLBENCH_INSTALL_PREFIX}/lib64:'
-        f'{NIXL_INSTALL_PREFIX}/lib64:{NIXL_INSTALL_PREFIX}/lib64/plugins:'
-        f'{NIXL_INSTALL_PREFIX}/lib/\\$(uname -m)-linux-gnu:'
-        f'{NIXL_INSTALL_PREFIX}/lib/\\$(uname -m)-linux-gnu/plugins:'
-        f'/usr/local/lib64:/usr/local/lib:/opt/ucx/lib:'
-        f'\\$LD_LIBRARY_PATH" >> /etc/profile.d/nixlbench.sh && '
-        f'chmod +x /etc/profile.d/nixlbench.sh && '
-        # Also create symlinks in /usr/local/bin for immediate availability
-        f'ln -sf {NIXLBENCH_INSTALL_PREFIX}/bin/nixlbench /usr/local/bin/nixlbench'
-    )
-    if not _run_build_step(pod_name, env_setup, "environment setup", _out):
-        _out(f"    Warning: PATH setup failed. nixlbench may not be found via command -v.")
+    if not nonroot:
+        # Root path: set up profile.d and symlinks
+        env_setup = (
+            f'echo "export PATH={bench_pfx}/bin:{nixl_pfx}/bin:\\$PATH" '
+            f'> /etc/profile.d/nixlbench.sh && '
+            f'echo "export LD_LIBRARY_PATH={bench_pfx}/lib:'
+            f'{bench_pfx}/lib64:'
+            f'{nixl_pfx}/lib64:{nixl_pfx}/lib64/plugins:'
+            f'{nixl_pfx}/lib/\\$(uname -m)-linux-gnu:'
+            f'{nixl_pfx}/lib/\\$(uname -m)-linux-gnu/plugins:'
+            f'/usr/local/lib64:/usr/local/lib:/opt/ucx/lib:'
+            f'\\$LD_LIBRARY_PATH" >> /etc/profile.d/nixlbench.sh && '
+            f'chmod +x /etc/profile.d/nixlbench.sh && '
+            f'ln -sf {bench_pfx}/bin/nixlbench /usr/local/bin/nixlbench'
+        )
+        if not _run_build_step(pod_name, env_setup, "environment setup", _out):
+            _out(f"    Warning: PATH setup failed. nixlbench may not be found via command -v.")
+    else:
+        _out(f"    Non-root: nixlbench installed at {bench_pfx}/bin/ (using LD_LIBRARY_PATH)")
 
-    _out(f"  nixlbench built and installed at {NIXLBENCH_INSTALL_PREFIX} on {pod_name}.")
+    _out(f"  nixlbench built and installed at {bench_pfx} on {pod_name}.")
+    return True
+
+
+def _check_pip_nixl_libs(pod_name):
+    """Check if NIXL libs are available from the pip package."""
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c", f"test -f {NIXL_PIP_LIBS}/libnixl.so && echo FOUND"],
+        use_debug=False,
+    )
+    return result.returncode == 0 and "FOUND" in (result.stdout or "")
+
+
+def _setup_pip_nixl_for_build(pod_name, out=None):
+    """Set up NIXL from pip package for building nixlbench against it.
+
+    Creates a fake NIXL install prefix at NONROOT_NIXL_PREFIX with:
+    - lib64/ symlinked to pip package libs (libnixl.so, libnixl_build.so, libserdes.so)
+    - include/ from the cloned NIXL source (src/api/cpp/ headers)
+    """
+    _out = out or print
+    nixl_pfx = NONROOT_NIXL_PREFIX if _detect_nonroot(pod_name) else NIXL_INSTALL_PREFIX
+    nixl_src = f"{NIXL_BUILD_DIR}/nixl"
+
+    _out(f"  Reusing NIXL libs from pip package (nixl_cu12) ...")
+
+    # nixlbench meson.build looks for: nixl_path/include/ and nixl_path/<libdir>/
+    setup_cmd = (
+        f"mkdir -p {nixl_pfx}/lib64 {nixl_pfx}/include && "
+        # Symlink .so files from pip .mesonpy.libs (libnixl.so, libnixl_build.so, libserdes.so etc)
+        f"for f in {NIXL_PIP_LIBS}/lib*.so*; do "
+        f"  [ -f \"$f\" ] && ln -sf \"$f\" {nixl_pfx}/lib64/$(basename \"$f\") || true; "
+        f"done && "
+        # Symlink plugins directory (UCX backend etc)
+        f"ln -sfn {NIXL_PIP_LIBS}/plugins {nixl_pfx}/lib64/plugins && "
+        # Copy API headers from cloned source (nixlbench uses nixl_path/include/)
+        f"cp -r {nixl_src}/src/api/cpp/*.h {nixl_pfx}/include/ 2>/dev/null || true && "
+        # Also copy backend headers if present
+        f"mkdir -p {nixl_pfx}/include/backend && "
+        f"cp -r {nixl_src}/src/api/cpp/backend/*.h {nixl_pfx}/include/backend/ 2>/dev/null || true && "
+        # Copy infra headers (nixl_descriptors.h deps)
+        f"cp -r {nixl_src}/src/infra/*.h {nixl_pfx}/include/ 2>/dev/null || true && "
+        # Copy all internal utility headers recursively (nixlbench uses utils/common/, utils/serdes/ etc)
+        f"cp -a {nixl_src}/src/utils {nixl_pfx}/include/ 2>/dev/null || true && "
+        f"echo DONE"
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", setup_cmd], timeout=30, use_debug=False)
+    if result.returncode != 0 or "DONE" not in (result.stdout or ""):
+        _out(f"    Warning: failed to set up pip NIXL libs: {(result.stderr or '').strip()[:200]}")
+        return False
+
+    # Verify the critical files
+    verify = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         f"test -f {nixl_pfx}/lib64/libnixl.so && "
+         f"test -f {nixl_pfx}/lib64/libnixl_build.so && "
+         f"test -f {nixl_pfx}/lib64/libserdes.so && "
+         f"test -f {nixl_pfx}/include/nixl.h && echo OK"],
+        use_debug=False,
+    )
+    if "OK" not in (verify.stdout or ""):
+        _out(f"    Warning: NIXL prefix verification failed — missing libs or headers")
+        return False
+
+    _out(f"    NIXL prefix set up at {nixl_pfx} (libs from pip, headers from source)")
     return True
 
 
@@ -592,6 +954,7 @@ def build_nixlbench_from_source(pod_name, out=None):
     """Full build pipeline: deps -> etcd-cpp-api -> NIXL -> nixlbench."""
     _out = out or print
     _out(f"  === Building nixlbench from source on {pod_name} ===")
+    nonroot = _detect_nonroot(pod_name)
 
     # Ensure build directory exists
     exec_in_pod(pod_name, ["mkdir", "-p", NIXL_BUILD_DIR], use_debug=False)
@@ -600,12 +963,33 @@ def build_nixlbench_from_source(pod_name, out=None):
     if not install_nixlbench_deps(pod_name, out=_out):
         return False
 
+    # Step 1.5: Create git stub if git is not available (meson needs it for version info)
+    if nonroot:
+        exec_in_pod(
+            pod_name,
+            ["bash", "-c",
+             f"mkdir -p {NONROOT_BIN} && "
+             f"if ! command -v git >/dev/null 2>&1; then "
+             f"cat > {NONROOT_BIN}/git << 'GITEOF'\n"
+             "#!/bin/bash\n"
+             "if [[ \"$*\" == *\"rev-parse\"* ]]; then echo \"00000000\"; exit 0; "
+             "elif [[ \"$*\" == *\"describe\"* ]]; then echo \"v0.0.0\"; exit 0; "
+             "elif [[ \"$*\" == *\"submodule\"* ]]; then exit 0; "
+             "elif [[ \"$*\" == *\"clone\"* ]]; then echo \"git stub: clone not supported\" >&2; exit 1; "
+             "else exit 0; fi\n"
+             f"GITEOF\n"
+             f"chmod +x {NONROOT_BIN}/git; fi"],
+            use_debug=False,
+        )
+
     # Step 2: Build etcd-cpp-apiv3 (optional but needed for multi-node)
     etcd_ok = build_etcd_cpp_api(pod_name, out=_out)
     if not etcd_ok:
         _out(f"  Continuing without etcd-cpp-apiv3 (nixlbench etcd runtime will be disabled).")
 
-    # Step 3: Build NIXL library
+    # Step 3: Build NIXL from source (full build for consistent headers + libs)
+    # Note: pip NIXL libs have version mismatches with the public source headers,
+    # so we always do a full build from source for ABI compatibility.
     if not build_nixl(pod_name, out=_out):
         _out(f"  NIXL build failed. Cannot continue.")
         return False
@@ -636,18 +1020,20 @@ def install_etcd(pod_name, out=None):
         _out(f"  Re-run with --install-deps to automatically install etcd.")
         sys.exit(1)
 
-    _out(f"  Installing etcd {ETCD_VER} on {pod_name} ...")
+    bin_dir = _get_bin_dir(pod_name)
+    _out(f"  Installing etcd {ETCD_VER} on {pod_name} (to {bin_dir}) ...")
     install_script = (
+        f'mkdir -p {bin_dir} && '
         f'curl -L {ETCD_DOWNLOAD_URL} -o /tmp/etcd.tar.gz'
         f' && tar xzf /tmp/etcd.tar.gz -C /tmp'
-        f' && cp /tmp/etcd-{ETCD_VER}-linux-amd64/etcd /usr/local/bin/'
-        f' && cp /tmp/etcd-{ETCD_VER}-linux-amd64/etcdctl /usr/local/bin/'
+        f' && cp /tmp/etcd-{ETCD_VER}-linux-amd64/etcd {bin_dir}/'
+        f' && cp /tmp/etcd-{ETCD_VER}-linux-amd64/etcdctl {bin_dir}/'
         f' && rm -rf /tmp/etcd*'
         f' && echo "ETCD_INSTALLED"'
     )
     result = exec_in_pod(pod_name, ["bash", "-c", install_script], timeout=120, use_debug=False)
     if result.returncode != 0 or "ETCD_INSTALLED" not in result.stdout:
-        _out(f"  Error: failed to install etcd: {result.stderr.strip()[:200]}")
+        _out(f"  Error: failed to install etcd: {(result.stderr or result.stdout or '').strip()[:200]}")
         return False
     _out(f"  etcd {ETCD_VER} installed on {pod_name}.")
     return True
@@ -661,13 +1047,16 @@ def start_etcd_server(pod_name, pod_ip, out=None):
     _out = out or print
     _c = _get_common()
 
+    bin_dir = _get_bin_dir(pod_name)
     etcd_args = [
-        "etcd",
-        "--data-dir=/tmp/etcd-nixlbench-data",
-        f"--listen-client-urls=http://0.0.0.0:{ETCD_PORT}",
-        f"--advertise-client-urls=http://{pod_ip}:{ETCD_PORT}",
-        f"--listen-peer-urls=http://0.0.0.0:2380",
-        f"--initial-advertise-peer-urls=http://{pod_ip}:2380",
+        "bash", "-c",
+        f"export PATH={bin_dir}:/usr/local/bin:$PATH && "
+        f"etcd "
+        f"--data-dir=/tmp/etcd-nixlbench-data "
+        f"--listen-client-urls=http://0.0.0.0:{ETCD_PORT} "
+        f"--advertise-client-urls=http://{pod_ip}:{ETCD_PORT} "
+        f"--listen-peer-urls=http://0.0.0.0:2380 "
+        f"--initial-advertise-peer-urls=http://{pod_ip}:2380 "
         f"--initial-cluster=default=http://{pod_ip}:2380",
     ]
     cmd = _c._build_remote_cmd(pod_name, etcd_args)
@@ -683,7 +1072,9 @@ def start_etcd_server(pod_name, pod_ip, out=None):
     time.sleep(2)
     health_result = exec_in_pod(
         pod_name,
-        ["etcdctl", "endpoint", "health", f"--endpoints=http://localhost:{ETCD_PORT}"],
+        ["bash", "-c",
+         f"export PATH={bin_dir}:/usr/local/bin:$PATH && "
+         f"etcdctl endpoint health --endpoints=http://localhost:{ETCD_PORT}"],
         use_debug=False,
     )
     if health_result.returncode != 0:
@@ -718,7 +1109,9 @@ def cleanup_etcd_state(pod_name, etcd_endpoint, group=None, out=None):
     prefix = f"xferbench/{group}" if group else "xferbench"
     exec_in_pod(
         pod_name,
-        ["etcdctl", "del", prefix, "--prefix=true", f"--endpoints={etcd_endpoint}"],
+        ["bash", "-c",
+         f"export PATH={NONROOT_BIN}:/usr/local/bin:$PATH && "
+         f"etcdctl del {prefix} --prefix=true --endpoints={etcd_endpoint}"],
         use_debug=False,
     )
     if _get_common().VERBOSE:
@@ -728,60 +1121,121 @@ def cleanup_etcd_state(pod_name, etcd_endpoint, group=None, out=None):
 # ---------------------------------------------------------------------------
 # NIXLBench execution
 # ---------------------------------------------------------------------------
-def _build_nixlbench_cmd(etcd_endpoint, benchmark_group):
-    """Build full shell command for nixlbench with proper PATH/LD_LIBRARY_PATH."""
-    # Convert buffer size to raw bytes (nixlbench expects uint64, not "8G")
-    buffer_bytes = _get_common()._parse_size(NIXLBENCH_BUFFER_SIZE)
-    nixl_args = (
-        f"--etcd_endpoints {etcd_endpoint} "
-        f"--benchmark_group {benchmark_group} "
-        f"--backend {NIXLBENCH_BACKEND} "
-        f"--initiator_seg_type {NIXLBENCH_SEG_TYPE} "
-        f"--target_seg_type {NIXLBENCH_SEG_TYPE} "
-        f"--op_type WRITE "
-        f"--total_buffer_size {buffer_bytes}"
+NIXLBENCH_ASIO_PORT = 12345
+
+
+def _check_etcd_in_binary(pod_name):
+    """Check if nixlbench was built with working etcd runtime (not just listed in help)."""
+    nixl_pfx, bench_pfx, _local_pfx = _get_install_prefix(pod_name)
+    nonroot_pfx = _nonroot_env_prefix(pod_name)
+    env_prefix = (
+        f'{nonroot_pfx}'
+        f'export PATH={bench_pfx}/bin:{nixl_pfx}/bin:'
+        f'{NONROOT_BIN}:/usr/local/bin:$PATH && '
+        f'export LD_LIBRARY_PATH={bench_pfx}/lib:'
+        f'{bench_pfx}/lib64:'
+        f'{nixl_pfx}/lib64:{nixl_pfx}/lib64/plugins:'
+        f'{nixl_pfx}/lib/$(uname -m)-linux-gnu:'
+        f'{NIXL_PIP_LIBS}:{NIXL_PIP_UCX_LIBS}:'
+        f'/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}}'
     )
-    # Wrap in bash to set PATH/LD_LIBRARY_PATH for built-from-source installs
-    # Include both lib64 (RHEL) and lib/<arch>-linux-gnu (Debian) paths
+    result = exec_in_pod(
+        pod_name,
+        ["bash", "-c",
+         f'{env_prefix} && nixlbench --etcd_endpoints http://127.0.0.1:1 '
+         f'--benchmark_group test 2>&1 | head -5'],
+        timeout=10, use_debug=False,
+    )
+    output = (result.stdout or "") + (result.stderr or "")
+    return "Invalid runtime" not in output
+
+
+def _build_nixlbench_cmd(etcd_endpoint, benchmark_group, pod_name=None,
+                         runtime_type=None, asio_address=None):
+    """Build full shell command for nixlbench with proper PATH/LD_LIBRARY_PATH."""
+    buffer_bytes = _get_common()._parse_size(NIXLBENCH_BUFFER_SIZE)
+
+    if runtime_type == "ASIO":
+        nixl_args = (
+            f"-runtime_type ASIO "
+            f"-asio_address {asio_address or '127.0.0.1'} "
+            f"-asio_port {NIXLBENCH_ASIO_PORT} "
+            f"--backend {NIXLBENCH_BACKEND} "
+            f"--initiator_seg_type {NIXLBENCH_SEG_TYPE} "
+            f"--target_seg_type {NIXLBENCH_SEG_TYPE} "
+            f"--op_type WRITE "
+            f"--total_buffer_size {buffer_bytes}"
+        )
+    else:
+        nixl_args = (
+            f"--etcd_endpoints {etcd_endpoint} "
+            f"--benchmark_group {benchmark_group} "
+            f"--backend {NIXLBENCH_BACKEND} "
+            f"--initiator_seg_type {NIXLBENCH_SEG_TYPE} "
+            f"--target_seg_type {NIXLBENCH_SEG_TYPE} "
+            f"--op_type WRITE "
+            f"--total_buffer_size {buffer_bytes}"
+        )
+    # Include both standard and non-root paths for maximum compatibility
     env_setup = (
-        f"export PATH={NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:"
+        f"export HOME=/tmp && "
+        f"export PATH={NONROOT_NIXLBENCH_PREFIX}/bin:{NONROOT_NIXL_PREFIX}/bin:"
+        f"{NONROOT_BIN}:"
+        f"{NIXLBENCH_INSTALL_PREFIX}/bin:{NIXL_INSTALL_PREFIX}/bin:"
         f"/usr/local/bin:$PATH && "
-        f"export LD_LIBRARY_PATH={NIXLBENCH_INSTALL_PREFIX}/lib:"
-        f"{NIXLBENCH_INSTALL_PREFIX}/lib64:"
-        f"{NIXL_INSTALL_PREFIX}/lib64:"
-        f"{NIXL_INSTALL_PREFIX}/lib64/plugins:"
+        f"export LD_LIBRARY_PATH={NONROOT_NIXLBENCH_PREFIX}/lib:"
+        f"{NONROOT_NIXLBENCH_PREFIX}/lib64:"
+        f"{NONROOT_NIXL_PREFIX}/lib64:{NONROOT_NIXL_PREFIX}/lib64/plugins:"
+        f"{NONROOT_NIXL_PREFIX}/lib/$(uname -m)-linux-gnu:"
+        f"{NONROOT_NIXL_PREFIX}/lib/$(uname -m)-linux-gnu/plugins:"
+        f"{NONROOT_PREFIX}/lib64:{NONROOT_PREFIX}/lib:"
+        f"{NIXL_PIP_LIBS}:{NIXL_PIP_UCX_LIBS}:"
+        f"{NIXLBENCH_INSTALL_PREFIX}/lib:{NIXLBENCH_INSTALL_PREFIX}/lib64:"
+        f"{NIXL_INSTALL_PREFIX}/lib64:{NIXL_INSTALL_PREFIX}/lib64/plugins:"
         f"{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu:"
         f"{NIXL_INSTALL_PREFIX}/lib/$(uname -m)-linux-gnu/plugins:"
-        f"/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH"
+        f"/opt/ucx/lib:/usr/local/lib64:/usr/local/lib:${{LD_LIBRARY_PATH:-}}"
     )
     return ["bash", "-c", f"{env_setup} && {NIXLBENCH_BINARY} {nixl_args}"]
 
 
-def run_nixlbench_pair(src_pod, src_ip, dst_pod, dst_ip, etcd_endpoint, group, out=None):
+def run_nixlbench_pair(src_pod, src_ip, dst_pod, dst_ip, etcd_endpoint, group,
+                       out=None, use_asio=False):
     """Run nixlbench between two pods. Returns parsed metrics dict or None.
 
     Launches target first (Popen), then initiator (subprocess.run blocking).
-    Both self-register via etcd to get ranks.
+    When use_asio=True, uses direct ASIO socket communication (no etcd needed).
+    Otherwise uses etcd for rank coordination.
     """
     _out = out or print
     _c = _get_common()
 
-    nixl_cmd_args = _build_nixlbench_cmd(etcd_endpoint, group)
-    short_desc = f"nixlbench --backend {NIXLBENCH_BACKEND} --benchmark_group {group}"
+    if use_asio:
+        # ASIO: both use dst_ip as address. First to start binds (rank 0),
+        # second fails bind and connects (rank 1). Target starts first.
+        target_cmd_args = _build_nixlbench_cmd(
+            etcd_endpoint, group, runtime_type="ASIO", asio_address=dst_ip)
+        initiator_cmd_args = _build_nixlbench_cmd(
+            etcd_endpoint, group, runtime_type="ASIO", asio_address=dst_ip)
+        short_desc = f"nixlbench --backend {NIXLBENCH_BACKEND} -runtime_type ASIO"
+    else:
+        target_cmd_args = _build_nixlbench_cmd(etcd_endpoint, group)
+        initiator_cmd_args = _build_nixlbench_cmd(etcd_endpoint, group)
+        short_desc = f"nixlbench --backend {NIXLBENCH_BACKEND} --benchmark_group {group}"
 
     # Start target (background)
-    target_cmd = _c._build_remote_cmd(dst_pod, nixl_cmd_args)
+    target_cmd = _c._build_remote_cmd(dst_pod, target_cmd_args)
     _out(f"  Target: {short_desc}")
     if _c.VERBOSE:
         _out(f"  $ {' '.join(target_cmd)}")
     target_proc = subprocess.Popen(target_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     _c._server_procs_append(target_proc)
 
-    # Brief delay for target to register with etcd
-    time.sleep(2)
+    # Brief delay for target to start listening
+    time.sleep(3 if use_asio else 2)
 
     # Start initiator (blocking)
-    initiator_cmd = _c._build_remote_cmd(src_pod, nixl_cmd_args)
+    initiator_cmd = _c._build_remote_cmd(src_pod, initiator_cmd_args)
     _out(f"  Initiator: {short_desc}")
     if _c.VERBOSE:
         _out(f"  $ {' '.join(initiator_cmd)}")
@@ -813,8 +1267,9 @@ def run_nixlbench_pair(src_pod, src_ip, dst_pod, dst_ip, etcd_endpoint, group, o
         target_out = target_stdout.decode("utf-8", errors="replace") if isinstance(target_stdout, bytes) else target_stdout
         _out(f"  nixlbench target output ({len(target_out)} chars):\n{target_out[-2000:]}")
 
-    # Clean up etcd state for this group
-    cleanup_etcd_state(_etcd_pod_name, etcd_endpoint, group=group, out=_out)
+    # Clean up etcd state for this group (only when using etcd runtime)
+    if not use_asio:
+        cleanup_etcd_state(_etcd_pod_name, etcd_endpoint, group=group, out=_out)
 
     if result is None or result.returncode != 0:
         stderr_msg = result.stderr.strip()[:200] if result else "timeout"
@@ -932,7 +1387,7 @@ def parse_nixlbench_output(stdout, out=None):
     return metrics
 
 
-def _run_nixlbench_matrix(pods, display_names, etcd_endpoint):
+def _run_nixlbench_matrix(pods, display_names, etcd_endpoint, use_asio=False):
     """Run nixlbench for all pod pairs. Returns dict of metric_name -> NxN matrix."""
     _c = _get_common()
     n = len(pods)
@@ -981,6 +1436,7 @@ def _run_nixlbench_matrix(pods, display_names, etcd_endpoint):
                 pair_metrics = run_nixlbench_pair(
                     src_name, src_ip, dst_name, dst_ip,
                     etcd_endpoint, group, out=_out,
+                    use_asio=use_asio,
                 )
                 if pair_metrics:
                     for k, v in pair_metrics.items():
@@ -1104,22 +1560,29 @@ def run_nixlbench(pods, display_names):
         print(f"\n  Aborting: nixlbench not available on {', '.join(failed_pods)}")
         return {}
 
-    # --- Step 2: Install/verify etcd on pod 0 ---
+    # --- Step 2: Detect runtime mode (ASIO if etcd support not compiled in) ---
     etcd_pod_name, etcd_pod_ip = pods[0]
     _etcd_pod_name = etcd_pod_name
-    print(f"\nSetting up etcd on {display_names[etcd_pod_name]} ...")
-    install_etcd(etcd_pod_name)
-
-    # --- Step 3: Start etcd server ---
-    etcd_proc = start_etcd_server(etcd_pod_name, etcd_pod_ip)
-    etcd_endpoint = f"http://{etcd_pod_ip}:{ETCD_PORT}"
+    use_asio = not _check_etcd_in_binary(etcd_pod_name)
+    if use_asio:
+        print(f"\n  Using ASIO runtime (nixlbench built without etcd-cpp-api)")
+        etcd_endpoint = ""
+        etcd_proc = None
+    else:
+        print(f"\nSetting up etcd on {display_names[etcd_pod_name]} ...")
+        install_etcd(etcd_pod_name)
+        # --- Step 3: Start etcd server ---
+        etcd_proc = start_etcd_server(etcd_pod_name, etcd_pod_ip)
+        etcd_endpoint = f"http://{etcd_pod_ip}:{ETCD_PORT}"
 
     try:
         # --- Step 4: Run nixlbench matrix ---
-        results = _run_nixlbench_matrix(pods, display_names, etcd_endpoint)
+        results = _run_nixlbench_matrix(pods, display_names, etcd_endpoint,
+                                        use_asio=use_asio)
     finally:
         # --- Step 5: Stop etcd ---
-        stop_etcd_server(etcd_proc)
+        if etcd_proc:
+            stop_etcd_server(etcd_proc)
 
     return results
 
@@ -1161,9 +1624,9 @@ Options:
 
     _c = _get_common()
     _cfg = _c._parse_common_args(extra_flags={
-        ("--nixlbench-backend",):       ("_NIXLBENCH_BACKEND", True),
-        ("--nixlbench-seg-type",):      ("_NIXLBENCH_SEG_TYPE", True),
-        ("--nixlbench-buffer-size",):   ("_NIXLBENCH_BUFFER_SIZE", True),
+        ("--nixlbench-backend", "--nixlbench-backend"):       ("_NIXLBENCH_BACKEND", True),
+        ("--nixlbench-seg-type", "--nixlbench-seg-type"):     ("_NIXLBENCH_SEG_TYPE", True),
+        ("--nixlbench-buffer-size", "--nixlbench-buffer-size"): ("_NIXLBENCH_BUFFER_SIZE", True),
     })
 
     # Apply nixlbench-specific config

--- a/run-tests-perftest.py
+++ b/run-tests-perftest.py
@@ -1,0 +1,659 @@
+# /// script
+# requires-python = ">=3.10"
+# ///
+"""RDMA perftest runner for Kubernetes inference pods.
+
+Extracted from run-tests.py — runs ib_{read,write,send}_{lat,bw} tests
+between pods, auto-detects RDMA devices and GID indexes, and optionally
+installs/builds perftest from source.
+
+Public API:
+    run_perftest(pods, display_names) -> dict
+    install_all_deps(pod_name) -> None
+    build_perftest(pod_name) -> None
+    perftest_available(pod_name) -> bool
+    detect_rdma_config(pod_name) -> (device, gid_index)
+"""
+
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+
+from importlib import import_module
+
+# Import shared utilities from the common module.
+_common = None
+
+
+def _get_common():
+    global _common
+    if _common is None:
+        _common = import_module("run-tests-common")
+    return _common
+
+
+# Delegated to run-tests-common
+def run_cmd(*args, **kwargs):
+    return _get_common().run_cmd(*args, **kwargs)
+
+
+def exec_in_pod(*args, **kwargs):
+    return _get_common().exec_in_pod(*args, **kwargs)
+
+
+def _kubectl_ns_args():
+    return _get_common()._kubectl_ns_args()
+
+
+def _human_size(n):
+    return _get_common()._human_size(n)
+
+
+# ---------------------------------------------------------------------------
+# Perftest constants
+# ---------------------------------------------------------------------------
+PERFTEST_BINARIES = [
+    "ib_read_lat", "ib_write_lat", "ib_send_lat",
+    "ib_read_bw", "ib_write_bw", "ib_send_bw",
+]
+PERFTEST_REPO = "https://github.com/linux-rdma/perftest.git"
+PERFTEST_DEPS = [
+    "libibverbs-devel", "libibverbs-utils", "librdmacm-devel",
+    "pciutils-devel", "automake", "autoconf", "libtool",
+]
+
+
+# ---------------------------------------------------------------------------
+# Perftest functions
+# ---------------------------------------------------------------------------
+def _check_binaries(pod_name, binaries):
+    """Check which binaries are available on a pod in a single exec call.
+
+    Returns a set of binaries that are missing.
+    """
+    # Build a one-liner: for each binary, print FOUND:<name> or MISSING:<name>
+    checks = " && ".join(
+        f'(command -v {b} >/dev/null 2>&1 && echo "FOUND:{b}" || echo "MISSING:{b}")'
+        for b in binaries
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", checks], use_debug=False)
+    missing = set()
+    if result.returncode != 0:
+        return set(binaries)  # assume all missing on failure
+    for line in result.stdout.strip().split("\n"):
+        line = line.strip()
+        if line.startswith("MISSING:"):
+            missing.add(line[8:])
+    return missing
+
+
+def perftest_available(pod_name):
+    """Check if all perftest binaries are available on the pod."""
+    return len(_check_binaries(pod_name, PERFTEST_BINARIES)) == 0
+
+
+def install_all_deps(pod_name, out=None):
+    """Install all dependencies for every test on a pod.
+
+    Installs packages for ping (iputils-ping), iperf3, and perftest build
+    dependencies regardless of which tests are selected, so that any test
+    can be re-run later without repeating the install step.
+    """
+    _out = out or print
+    _out(f"  Installing all test dependencies on {pod_name} ...")
+
+    # Package groups — installed one group at a time so a failure in one
+    # (e.g. iputils on a read-only filesystem) doesn't block the rest.
+    rpm_groups = [
+        (["iperf3"], "iperf3"),
+        (["libibverbs-utils", "infiniband-diags"], "RDMA diagnostic tools (ibv_devices, ibstat)"),
+        (PERFTEST_DEPS + ["git", "make", "gcc"], "perftest build tools"),
+    ]
+    apt_groups = [
+        (["iperf3"], "iperf3"),
+        (["ibverbs-utils", "infiniband-diags"], "RDMA diagnostic tools (ibv_devices, ibstat)"),
+        ([
+            "libibverbs-dev", "ibverbs-utils", "librdmacm-dev", "libpci-dev",
+            "automake", "autoconf", "libtool", "git", "make", "gcc",
+        ], "perftest build tools"),
+    ]
+
+    def _install_status(result, label, already_patterns):
+        """Print install/skip/fail status based on command output."""
+        if result.returncode != 0:
+            _out(f"  Warning: failed to install {label}: {result.stderr.strip()[:200]}")
+        else:
+            stdout = (result.stdout or "").lower()
+            if any(p in stdout for p in already_patterns):
+                _out(f"    Skipped {label} (already installed).")
+            else:
+                _out(f"    Installed {label}.")
+
+    rpm_already = ["already installed", "nothing to do"]
+    apt_already = ["already the newest version", "is already the newest"]
+
+    for pkg_mgr, install_cmd in [
+        ("dnf", ["dnf", "install", "-y"]),
+        ("yum", ["yum", "install", "-y"]),
+    ]:
+        check = exec_in_pod(pod_name, ["which", pkg_mgr], use_debug=False)
+        if check.returncode == 0:
+            for pkgs, label in rpm_groups:
+                result = exec_in_pod(pod_name, install_cmd + pkgs, timeout=300, use_debug=False)
+                _install_status(result, label, rpm_already)
+            break
+    else:
+        exec_in_pod(pod_name, ["apt-get", "update"], timeout=120, use_debug=False)
+        for pkgs, label in apt_groups:
+            result = exec_in_pod(pod_name, ["apt-get", "install", "-y"] + pkgs, timeout=300, use_debug=False)
+            _install_status(result, label, apt_already)
+
+    _out(f"  Package installation complete on {pod_name}.")
+
+
+def build_perftest(pod_name, out=None):
+    """Clone and build perftest from source on a pod's main container."""
+    _out = out or print
+    _out(f"  Cloning perftest on {pod_name} ...")
+    exec_in_pod(pod_name, ["rm", "-rf", "/tmp/perftest"], use_debug=False)
+    result = exec_in_pod(pod_name, ["git", "clone", PERFTEST_REPO, "/tmp/perftest"], timeout=120, use_debug=False)
+    if result.returncode != 0:
+        _out(f"  Error cloning perftest: {result.stderr}")
+        return False
+
+    _out(f"  Building perftest on {pod_name} ...")
+    for step_cmd in [
+        ["bash", "-c", "cd /tmp/perftest && ./autogen.sh"],
+        ["bash", "-c", "cd /tmp/perftest && ./configure"],
+        ["bash", "-c", "cd /tmp/perftest && make -j$(nproc)"],
+        ["bash", "-c", "cd /tmp/perftest && make install"],
+    ]:
+        result = exec_in_pod(pod_name, step_cmd, timeout=300, use_debug=False)
+        if _get_common().VERBOSE and result.stdout.strip():
+            _out(result.stdout[-500:])
+        if result.returncode != 0:
+            _out(f"  Build step failed: {' '.join(step_cmd)}")
+            _out(f"  stderr: {result.stderr[-500:]}")
+            return False
+    _out(f"  perftest built successfully on {pod_name}.")
+    return True
+
+
+def ensure_perftest(pod_name, out=None):
+    _out = out or print
+    if perftest_available(pod_name):
+        _out(f"  perftest binaries already available on {pod_name}.")
+        return
+    if not _get_common().INSTALL_DEPS:
+        _out(f"  Error: perftest binaries not found on {pod_name}.")
+        _out(f"  Re-run with --install-deps to automatically build them.")
+        sys.exit(1)
+    _out(f"  perftest binaries not found on {pod_name}, building from source ...")
+    build_perftest(pod_name, out=_out)
+    if not perftest_available(pod_name):
+        _out(f"  Error: perftest binaries still not available after build on {pod_name}.")
+        sys.exit(1)
+
+
+def detect_rdma_device(pod_name):
+    result = exec_in_pod(pod_name, ["bash", "-c", "ls /sys/class/infiniband/ 2>/dev/null | head -1"], use_debug=False)
+    dev = result.stdout.strip()
+    if result.returncode != 0 or not dev:
+        print(f"  Warning: no RDMA devices found on {pod_name}", file=sys.stderr)
+        return None
+    return dev
+
+
+def detect_gid_index(pod_name, device):
+    script = (
+        f'for f in /sys/class/infiniband/{device}/ports/1/gid_attrs/types/*; do '
+        f'  idx=$(basename "$f"); '
+        f'  gtype=$(cat "$f" 2>/dev/null); '
+        f'  gid=$(cat /sys/class/infiniband/{device}/ports/1/gids/"$idx" 2>/dev/null); '
+        f'  [ -n "$gid" ] && [ "$gid" != "0000:0000:0000:0000:0000:0000:0000:0000" ] && '
+        f'  echo "$idx $gtype $gid"; '
+        f'done; true'
+    )
+    result = exec_in_pod(pod_name, ["bash", "-c", script], use_debug=False)
+    if result.stdout.strip():
+        rocev2_ipv4 = rocev2_any = rocev1_ipv4 = any_gid = None
+        for line in result.stdout.strip().split("\n"):
+            parts = line.split()
+            if len(parts) < 3:
+                continue
+            idx = parts[0]
+            gid = parts[-1]
+            gtype = " ".join(parts[1:-1])
+            is_ipv4_mapped = ":ffff:" in gid and not gid.startswith("fe80:")
+            is_rocev2 = "v2" in gtype.lower()
+            if _get_common().VERBOSE:
+                print(f"    GID[{idx}] type={gtype} gid={gid} ipv4={is_ipv4_mapped} rocev2={is_rocev2}")
+            if any_gid is None:
+                any_gid = idx
+            if is_rocev2 and is_ipv4_mapped:
+                rocev2_ipv4 = idx
+            elif is_rocev2 and rocev2_any is None:
+                rocev2_any = idx
+            elif not is_rocev2 and is_ipv4_mapped and rocev1_ipv4 is None:
+                rocev1_ipv4 = idx
+        chosen = rocev2_ipv4 or rocev2_any or rocev1_ipv4 or any_gid
+        if chosen is not None:
+            return chosen
+
+    # Fallback: ibv_devinfo
+    result = exec_in_pod(pod_name, ["ibv_devinfo", "-d", device, "-v"], use_debug=False)
+    if result.returncode == 0 and result.stdout.strip():
+        for match in re.finditer(r"GID\[\s*(\d+)\]:\s+(\S+)", result.stdout):
+            idx, gid = match.group(1), match.group(2)
+            if gid != "0000:0000:0000:0000:0000:0000:0000:0000":
+                return idx
+    return None
+
+
+def detect_rdma_config(pod_name):
+    device = _get_common().OPT_DEVICE or detect_rdma_device(pod_name)
+    gid_index = _get_common().OPT_GID_INDEX
+    if device and gid_index is None:
+        gid_index = detect_gid_index(pod_name, device)
+    print(f"  {pod_name}: device={device}, gid_index={gid_index}")
+    return device, gid_index
+
+
+def _is_latency_test(binary):
+    return binary.endswith("_lat")
+
+
+def _perftest_kind(binary):
+    """Extract operation name from binary, e.g. 'ib_read_bw' -> 'Read'."""
+    # binary format: ib_<op>_<lat|bw>
+    parts = binary.split("_")
+    if len(parts) >= 2:
+        return parts[1].capitalize()  # read->Read, write->Write, send->Send
+    return binary
+
+
+def build_perftest_args(binary, device, gid_index, port, size, server_ip=None):
+    """Build command-line args for any perftest binary (latency or bandwidth)."""
+    args = []
+    if server_ip:
+        args.append(server_ip)
+    if device:
+        args += ["-d", device]
+    if gid_index is not None:
+        args += ["-x", str(gid_index)]
+    args += ["-F", "-q", "1", "--port", str(port), "--size", str(size)]
+    if _is_latency_test(binary):
+        args += ["-n", str(_get_common().PERFTEST_ITERATIONS)]
+    else:
+        args += ["--report_gbits", "--duration", str(_get_common().PERFTEST_DURATION)]
+    return args
+
+
+def start_perftest_server(server_pod, binary, device, gid_index, port, size, out=None):
+    _out = out or print
+    ib_args = build_perftest_args(binary, device, gid_index, port, size)
+    cmd = _get_common()._build_remote_cmd(server_pod, [binary] + ib_args)
+
+    ib_cmd_str = f"{binary} {' '.join(ib_args)}"
+    _out(f"  Server cmd: {ib_cmd_str}")
+    if _get_common().VERBOSE:
+        _out(f"  $ {' '.join(cmd)}")
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    _get_common()._server_procs_append(proc)
+    _out(f"  Started {binary} server on {server_pod}, waiting 2s ...")
+    time.sleep(2)
+    return proc
+
+
+def run_perftest_client(client_pod, binary, server_ip, device, gid_index, port, size, out=None):
+    _out = out or print
+    ib_args = build_perftest_args(binary, device, gid_index, port, size, server_ip=server_ip)
+    cmd = _get_common()._build_remote_cmd(client_pod, [binary] + ib_args)
+
+    ib_cmd_str = f"{binary} {' '.join(ib_args)}"
+    _out(f"  Client cmd: {ib_cmd_str}")
+    if _get_common().VERBOSE:
+        _out(f"  $ {' '.join(cmd)}")
+    return subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+
+
+def parse_bw_output(output):
+    """Parse bandwidth test output (ib_read_bw / ib_write_bw).
+    Columns: #bytes, iterations, bw_peak, bw_avg, msg_rate
+    Returns avg bandwidth in Gb/s (when --report_gbits is used)."""
+    in_data = False
+    last_bw = None
+    for line in output.strip().split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("#bytes"):
+            in_data = True
+            continue
+        if in_data and stripped and stripped[0].isdigit():
+            parts = stripped.split()
+            if len(parts) >= 5:
+                last_bw = float(parts[3])  # bw_avg
+    return last_bw
+
+
+def parse_lat_output(output):
+    """Parse latency test output (ib_read_lat / ib_write_lat).
+    Columns: #bytes, iterations, t_min[usec], t_max[usec], t_typical[usec], t_avg[usec]
+    Returns avg latency in usec."""
+    in_data = False
+    last_lat = None
+    for line in output.strip().split("\n"):
+        stripped = line.strip()
+        if stripped.startswith("#bytes"):
+            in_data = True
+            continue
+        if in_data and stripped and stripped[0].isdigit():
+            parts = stripped.split()
+            if len(parts) >= 6:
+                last_lat = float(parts[5])  # t_avg
+    return last_lat
+
+
+def run_perftest_pair(src_name, dst_ip, src_dev, src_gid, dst_name, dst_dev, dst_gid,
+                      binary="ib_write_bw", port=None, size=65536, out=None):
+    """Run a single perftest binary between two pods. Returns parsed value or None."""
+    _out = out or print
+    if port is None:
+        port = _get_common().PERFTEST_PORT
+    proc = start_perftest_server(dst_name, binary, dst_dev, dst_gid, port, size, out=_out)
+    result = run_perftest_client(src_name, binary, dst_ip, src_dev, src_gid, port, size, out=_out)
+    # Cleanup this server
+    try:
+        proc.terminate()
+    except OSError:
+        pass
+    try:
+        proc.wait(timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        try:
+            proc.kill()
+        except OSError:
+            pass
+    _get_common()._server_procs_remove(proc)
+
+    if result.returncode != 0:
+        _out(f"    FAILED: {result.stderr.strip()}")
+        return None
+
+    if _is_latency_test(binary):
+        return parse_lat_output(result.stdout)
+    else:
+        return parse_bw_output(result.stdout)
+
+
+def _run_perftest_matrix(pods, display_names, rdma_configs, binary, port, size):
+    """Run a single perftest binary for all pairs at a given size. Returns matrix.
+
+    Non-interfering pairs (no shared source or destination pod) run in
+    parallel within the same wave, using one thread per pair.
+    """
+    _c = _get_common()
+    n = len(pods)
+    test_pairs = _c._cross_role_pairs(pods)
+    total_pairs = len(test_pairs)
+    is_lat = _is_latency_test(binary)
+    unit = "usec" if is_lat else "Gb/s"
+    size_label = _human_size(size)
+
+    print(f"\n{'─' * 50}")
+    print(f"  Running {binary} size={size_label} ({unit}) — port {port} — {total_pairs} pair(s)")
+    print(f"{'─' * 50}")
+
+    waves = _c._schedule_parallel_pairs(n, pairs=test_pairs)
+    matrix = [[None] * n for _ in range(n)]
+    done = 0
+
+    for wave_idx, wave in enumerate(waves):
+        pair_labels = ", ".join(
+            f"{display_names[pods[i][0]]}->{display_names[pods[j][0]]}"
+            for i, j in wave
+        )
+        print(f"\n  [wave {wave_idx + 1}/{len(waves)}] "
+              f"{len(wave)} pair(s) in parallel: {pair_labels}")
+
+        # Per-pair thread state
+        buffers = []
+        results_slot = [None] * len(wave)  # (i, j, value)
+        done_events = [threading.Event() for _ in wave]
+
+        def _worker(slot, i, j, buf, done_evt):
+            try:
+                src_name, _ = pods[i]
+                dst_name, dst_ip = pods[j]
+                src_short = display_names[src_name]
+                dst_short = display_names[dst_name]
+                src_dev, src_gid = rdma_configs[src_name]
+                dst_dev, dst_gid = rdma_configs[dst_name]
+
+                def _out(msg):
+                    buf.write(msg + "\n")
+
+                _out(f"\n    {src_short} -> {dst_short}")
+                val = run_perftest_pair(
+                    src_name, dst_ip, src_dev, src_gid,
+                    dst_name, dst_dev, dst_gid,
+                    binary=binary, port=port, size=size, out=_out,
+                )
+                if val is not None:
+                    fmt = f"{val:.4f}" if is_lat else f"{val:.2f}"
+                    _out(f"    {fmt} {unit}")
+                else:
+                    _out(f"    FAIL")
+                results_slot[slot] = (i, j, val)
+            except Exception as exc:
+                buf.write(f"\n    ERROR: {exc}\n")
+                results_slot[slot] = (i, j, None)
+            finally:
+                done_evt.set()
+
+        # Launch threads for this wave
+        threads = []
+        for slot, (i, j) in enumerate(wave):
+            buf = _c._StreamingBuffer()
+            buffers.append(buf)
+            t = threading.Thread(
+                target=_worker,
+                args=(slot, i, j, buf, done_events[slot]),
+                daemon=True,
+            )
+            threads.append(t)
+            t.start()
+
+        # Wait and flush output in pair order
+        for slot in range(len(wave)):
+            done_events[slot].wait()
+            buffers[slot].flush_all()
+
+        for t in threads:
+            t.join(timeout=5)
+
+        # Store results in matrix
+        for slot in range(len(wave)):
+            if results_slot[slot] is not None:
+                i, j, val = results_slot[slot]
+                matrix[i][j] = val
+                done += 1
+
+    print(f"\n  Completed {done}/{total_pairs} pair(s)")
+    return matrix
+
+
+def run_perftest(pods, display_names):
+    """Run latency tests (with --latency-size) and bandwidth tests (per --block-sizes)."""
+    bw_sizes_str = ", ".join(_human_size(s) for s in _get_common().RDMA_BLOCK_SIZES)
+    lat_size_str = _human_size(_get_common().RDMA_LATENCY_SIZE)
+    print(f"\n{'=' * 60}")
+    print("  PERFTEST (RDMA Latency & Bandwidth)")
+    print(f"{'=' * 60}")
+    print(f"Settings: duration={_get_common().PERFTEST_DURATION}s, iterations={_get_common().PERFTEST_ITERATIONS}, "
+          f"latency_size={lat_size_str}, bw_sizes=[{bw_sizes_str}], base_port={_get_common().PERFTEST_PORT}")
+
+    print("\nEnsuring perftest is available on all pods (parallel) ...")
+    _c = _get_common()
+    n = len(pods)
+    _ensure_bufs = [_c._StreamingBuffer() for _ in range(n)]
+    _ensure_done = [threading.Event() for _ in range(n)]
+
+    def _ensure_worker(idx, pod_name, buf, done_evt):
+        try:
+            ensure_perftest(pod_name, out=lambda msg: buf.write(msg + "\n"))
+        except SystemExit:
+            buf.write(f"  FATAL: perftest setup failed on {pod_name}\n")
+        except Exception as exc:
+            buf.write(f"  ERROR on {pod_name}: {exc}\n")
+        finally:
+            done_evt.set()
+
+    _ensure_threads = []
+    for _idx, (_name, _ip) in enumerate(pods):
+        _t = threading.Thread(
+            target=_ensure_worker,
+            args=(_idx, _name, _ensure_bufs[_idx], _ensure_done[_idx]),
+            daemon=True,
+        )
+        _ensure_threads.append(_t)
+        _t.start()
+
+    for _idx in range(n):
+        while not _ensure_done[_idx].is_set():
+            _ensure_bufs[_idx].flush_new()
+            _ensure_done[_idx].wait(timeout=0.1)
+        _ensure_bufs[_idx].flush_all()
+
+    for _t in _ensure_threads:
+        _t.join(timeout=5)
+
+    print("\nDetecting RDMA configuration on all pods ...")
+    rdma_configs = {}
+    for name, _ip in pods:
+        rdma_configs[name] = detect_rdma_config(name)
+
+    results = {}
+
+    # Latency tests — run once with RDMA_LATENCY_SIZE
+    for bin_idx, binary in enumerate(PERFTEST_BINARIES):
+        if not _is_latency_test(binary):
+            continue
+        port = _get_common().PERFTEST_PORT + bin_idx
+        matrix = _run_perftest_matrix(pods, display_names, rdma_configs,
+                                      binary, port, _get_common().RDMA_LATENCY_SIZE)
+        kind = _perftest_kind(binary)
+        results[f"RDMA {kind} Latency (usec)"] = matrix
+
+    # Bandwidth tests — run for each block size
+    for size in _get_common().RDMA_BLOCK_SIZES:
+        size_label = _human_size(size)
+        for bin_idx, binary in enumerate(PERFTEST_BINARIES):
+            if _is_latency_test(binary):
+                continue
+            port = _get_common().PERFTEST_PORT + bin_idx
+            matrix = _run_perftest_matrix(pods, display_names, rdma_configs,
+                                          binary, port, size)
+            kind = _perftest_kind(binary)
+            if len(_get_common().RDMA_BLOCK_SIZES) == 1:
+                key = f"RDMA {kind} BW (Gb/s)"
+            else:
+                key = f"RDMA {kind} BW {size_label} (Gb/s)"
+            results[key] = matrix
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Standalone entry point — allows:  uv run run-tests-perftest.py [options]
+# ---------------------------------------------------------------------------
+if __name__ == "__main__":
+    _USAGE = """\
+Usage: uv run run-tests-perftest.py [options]
+
+Run RDMA perftest (latency & bandwidth) between Kubernetes inference pods.
+
+Equivalent to: run-tests.sh -t perftest
+
+Options:
+  -b, --rdma-block-sizes SIZES
+                        Comma-separated message sizes for RDMA bandwidth
+                        (e.g. 64K,1M,1G).  Default: 1G.
+  -D, --debug-image IMAGE
+                        Use ephemeral debug containers with the given image.
+  -e, --explain         Show the kubectl/shell commands behind each finding.
+  -g, --gid-index INDEX GID index for RoCE.  Auto-detected if not specified.
+  -h, --help            Show this help message.
+  -i, --install-deps    Install perftest build tools and build from source.
+  -l, --label SELECTOR  Label selector to discover pods
+                        (default: "llm-d.ai/inferenceServing=true").
+  -n, --namespace NS    Kubernetes namespace for all kubectl commands.
+  -p, --percentage-margin PCT
+                        Flag results deviating more than PCT% from average
+                        (default: 10).
+  -r, --rdma-device DEVICE
+                        RDMA device to use (e.g. mlx5_0).  Auto-detected if
+                        not specified.
+  -s, --rdma-latency-size SIZE
+                        Message size for latency tests (default: 2 bytes).
+  -v, --verbose         Print kubectl commands as they run.
+  -x, --explain-verify  Run each explain command and verify output.
+                        Implies --explain.
+"""
+    if "-h" in sys.argv or "--help" in sys.argv:
+        print(_USAGE)
+        sys.exit(0)
+
+    _c = _get_common()
+    _cfg = _c._parse_common_args(extra_flags={
+        ("-r", "--rdma-device"):      ("OPT_DEVICE", True),
+        ("-g", "--gid-index"):        ("OPT_GID_INDEX", True),
+        ("-b", "--rdma-block-sizes"): ("_RDMA_BLOCK_SIZES_RAW", True),
+        ("-s", "--rdma-latency-size"): ("_RDMA_LATENCY_SIZE_RAW", True),
+    })
+
+    # Parse size strings into integers
+    _raw_bs = _cfg.pop("_RDMA_BLOCK_SIZES_RAW", None)
+    if _raw_bs:
+        _cfg["RDMA_BLOCK_SIZES"] = [_c._parse_size(s) for s in _raw_bs.split(",") if s.strip()]
+    _raw_ls = _cfg.pop("_RDMA_LATENCY_SIZE_RAW", None)
+    if _raw_ls:
+        _cfg["RDMA_LATENCY_SIZE"] = _c._parse_size(_raw_ls)
+
+    # Also pick up env-var overrides (same as run-tests.py)
+    _env_dev = os.environ.get("PERFTEST_DEVICE", "").strip()
+    if _env_dev and "OPT_DEVICE" not in _cfg:
+        _cfg["OPT_DEVICE"] = _env_dev
+    _env_gid = os.environ.get("PERFTEST_GID_INDEX", "").strip()
+    if _env_gid and "OPT_GID_INDEX" not in _cfg:
+        _cfg["OPT_GID_INDEX"] = _env_gid
+    _cfg.setdefault("PERFTEST_DURATION",
+                     int(os.environ.get("PERFTEST_DURATION", "5")))
+    _cfg.setdefault("PERFTEST_ITERATIONS",
+                     int(os.environ.get("PERFTEST_ITERATIONS", "1000")))
+    _cfg.setdefault("PERFTEST_PORT",
+                     int(os.environ.get("PERFTEST_PORT", "18515")))
+
+    _c.configure(**_cfg)
+
+    _pods, _display_names = _c._discover_and_display()
+    if _c.USE_DEBUG_CONTAINER:
+        print("\nCreating debug containers ...")
+        _c.create_debug_containers(_pods)
+
+    _results = run_perftest(_pods, _display_names)
+    # Print a simple summary
+    for _title, _matrix in _results.items():
+        print(f"\n{_title}:")
+        _header = [""] + [_display_names[p[0]] for p in _pods]
+        print("  " + "\t".join(_header))
+        for _i, (_name, _ip) in enumerate(_pods):
+            _row = [_display_names[_name]]
+            for _j in range(len(_pods)):
+                _val = _matrix[_i][_j]
+                _row.append(f"{_val:.2f}" if _val is not None else "-")
+            print("  " + "\t".join(_row))
+    _c.print_results_summary(_pods, _results, _display_names)
+

--- a/run-tests.py
+++ b/run-tests.py
@@ -1,0 +1,751 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "matplotlib>=3.7",
+# ]
+# ///
+"""Unified network test runner: perftest and iperf3 between pods.
+
+Discovers pods with label llm-d.ai/inferenceServing=true (override with
+--label SELECTOR) and runs selected tests between every pair.
+
+By default only runs perftest.  Use --tests to select:
+  --tests perftest          (default) RDMA latency & bandwidth
+                            (ib_{read,write,send}_{lat,bw})
+  --tests iperf3            iperf3 TCP bandwidth + UDP jitter/latency
+  --tests all               run both tests
+  --tests perftest,iperf3   same as all
+
+--rdma-block-sizes and --rdma-latency-size control RDMA perftest message sizes only.
+iperf3 uses its own defaults (128K TCP buffer, 8K UDP buffer).
+
+All tests run directly in the pod by default.  Pass --debug-image to use
+ephemeral debug containers instead.
+
+Pass --install-deps to automatically install iperf3 and build perftest
+from source when missing.
+"""
+
+import os
+import sys
+import threading
+
+from importlib import import_module as _import_module
+
+_common = _import_module("run-tests-common")
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+USAGE = """\
+Usage: run-tests.sh [options]
+
+Run network tests (perftest, iperf3) between Kubernetes pods.
+
+By default only runs perftest (RDMA latency & bandwidth:
+ib_{read,write,send}_{lat,bw}).
+Use --tests to select which tests to run.
+
+Options:
+  -b, --rdma-block-sizes SIZES
+                        Comma-separated list of message sizes for RDMA
+                        perftest bandwidth (ib_{read,write,send}_bw).
+                        Accepts bytes or suffixes K/M/G (e.g. 64K,1M,1G).
+                        Does not affect iperf3. (default: 1G).
+  -d, --discover-topology
+                        Only run GPU topology discovery (nvidia-smi topo,
+                        nvlink status, lscpu, lspci) and exit without
+                        running any network tests.  Note: topology discovery
+                        also runs by default before tests; use -t to skip it
+                        and run only the specified tests.
+  -D, --debug-image IMAGE
+                        Use ephemeral debug containers with the given image.
+                        Optional — by default all tests run directly in the
+                        pod's main container.
+  -e, --explain         Show the kubectl/shell commands used to determine
+                        each finding, so results can be reproduced manually.
+  -g, --gid-index INDEX GID index for RoCE.  Auto-detected if not specified.
+  -x, --explain-verify  Run each explain command and verify it produces
+                        expected output.  Implies --explain.  Use with -d
+                        for a full self-test of the discovery logic.
+  -h, --help            Show this help message.
+  -i, --install-deps    Install all test dependencies on every pod:
+                        iperf3, perftest build tools, etcd, and nixlbench.
+                        Builds perftest and nixlbench from source if missing.
+  -l, --label SELECTOR  Label selector to discover pods (default:
+                        "llm-d.ai/inferenceServing=true").
+  -n, --namespace NS    Kubernetes namespace for all kubectl commands.
+                        Uses current context namespace if not specified.
+  -r, --rdma-device DEVICE
+                        RDMA device to use (e.g. mlx5_0).  Auto-detected if
+                        not specified.
+  -s, --rdma-latency-size SIZE
+                        Message size for RDMA perftest latency tests
+                        (ib_{read,write,send}_lat). Does not affect iperf3.
+                        (default: 2 bytes).
+  -t, --tests TESTS     Comma-separated list of tests to run.
+                        Choices: perftest, iperf3, nccl-rccl, nixlbench, all
+                        (default: perftest).  When -t is given explicitly,
+                        topology discovery is skipped (use -d to force it).
+  -p, --percentage-margin PCT
+                        Percentage margin for flagging outlier results.
+                        Any result deviating more than PCT% from the average
+                        is flagged (default: 10).
+  -v, --verbose         Print kubectl/SSH commands as they run.
+  --ssh-hosts HOSTS     Comma-separated list of SSH hosts to use instead of
+                        kubectl pod discovery.  Format: host1,host2 or
+                        user@host1,user@host2 or host1:ip1,host2:ip2.
+  --ssh-command CMD     SSH command to use (default: "ssh").  Example:
+                        "ssh -i /path/key -o StrictHostKeyChecking=no".
+                        Requires --ssh-hosts.
+  --nixlbench-backend BACKEND
+                        NIXLBench backend (default: UCX).
+  --nixlbench-seg-type TYPE
+                        NIXLBench segment type for initiator and target
+                        (default: VRAM).  Choices: DRAM, VRAM.
+  --nixlbench-buffer-size SIZE
+                        NIXLBench total buffer size (default: 8G).
+
+Environment variables:
+  PERFTEST_LABEL        Label selector (same as -l/--label).
+  PERFTEST_NAMESPACE    Kubernetes namespace (same as -n/--namespace).
+  PERFTEST_INSTALL_DEPS Set to 1/true/yes to enable -i/--install-deps via env.
+  PERFTEST_DEVICE       Override RDMA device (same as -r/--rdma-device).
+  PERFTEST_GID_INDEX    Override GID index (same as -g/--gid-index).
+  PERFTEST_DURATION     Test duration in seconds for BW tests (default: 5).
+  PERFTEST_ITERATIONS   Number of iterations for latency tests (default: 1000).
+  RDMA_BLOCK_SIZES      RDMA perftest BW message sizes (same as
+                        -b/--rdma-block-sizes, default: 1073741824).
+  RDMA_LATENCY_SIZE     RDMA perftest latency message size (same as
+                        -s/--rdma-latency-size, default: 2).
+  PERFTEST_PORT         Base port for perftest (default: 18515).
+  DEBUG_IMAGE           Debug container image (same as -D/--debug-image).
+"""
+
+if "-h" in sys.argv or "--help" in sys.argv:
+    print(USAGE)
+    sys.exit(0)
+
+VERBOSE = "-v" in sys.argv or "--verbose" in sys.argv
+DISCOVER_ONLY = "-d" in sys.argv or "--discover-topology" in sys.argv
+EXPLAIN_VERIFY = "-x" in sys.argv or "--explain-verify" in sys.argv
+EXPLAIN = "-e" in sys.argv or "--explain" in sys.argv or EXPLAIN_VERIFY
+
+DEBUG_IMAGE = os.environ.get("DEBUG_IMAGE", "").strip()
+INSTALL_DEPS = os.environ.get("PERFTEST_INSTALL_DEPS", "").strip() in ("1", "true", "yes")
+OPT_DEVICE = os.environ.get("PERFTEST_DEVICE", "").strip() or None
+OPT_GID_INDEX = os.environ.get("PERFTEST_GID_INDEX", "").strip() or None
+OPT_LABEL = os.environ.get("PERFTEST_LABEL", "").strip() or "llm-d.ai/inferenceServing=true"
+OPT_NAMESPACE = os.environ.get("PERFTEST_NAMESPACE", "").strip() or None
+OPT_TESTS = "perftest"
+_TESTS_EXPLICIT = False  # True when -t/--tests was passed on CLI
+OPT_RDMA_BLOCK_SIZES = os.environ.get("RDMA_BLOCK_SIZES", "1073741824").strip()  # default 1 GB
+OPT_RDMA_LATENCY_SIZE = os.environ.get("RDMA_LATENCY_SIZE", "2").strip()  # default 2 bytes
+OPT_PERCENTAGE_MARGIN = 10.0  # default 10%
+OPT_SSH_COMMAND = None
+OPT_SSH_HOSTS = None
+OPT_NIXLBENCH_BACKEND = "UCX"
+OPT_NIXLBENCH_SEG_TYPE = "VRAM"
+OPT_NIXLBENCH_BUFFER_SIZE = "8G"
+
+_skip_next = False
+for _i, _arg in enumerate(sys.argv[1:], 1):
+    if _skip_next:
+        _skip_next = False
+        continue
+    if _arg in ("-D", "--debug-image") and _i < len(sys.argv) - 1:
+        DEBUG_IMAGE = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--debug-image="):
+        DEBUG_IMAGE = _arg.split("=", 1)[1]
+    elif _arg in ("-r", "--rdma-device") and _i < len(sys.argv) - 1:
+        OPT_DEVICE = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--rdma-device="):
+        OPT_DEVICE = _arg.split("=", 1)[1]
+    elif _arg in ("-g", "--gid-index") and _i < len(sys.argv) - 1:
+        OPT_GID_INDEX = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--gid-index="):
+        OPT_GID_INDEX = _arg.split("=", 1)[1]
+    elif _arg in ("-l", "--label") and _i < len(sys.argv) - 1:
+        OPT_LABEL = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--label="):
+        OPT_LABEL = _arg.split("=", 1)[1]
+    elif _arg in ("-n", "--namespace") and _i < len(sys.argv) - 1:
+        OPT_NAMESPACE = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--namespace="):
+        OPT_NAMESPACE = _arg.split("=", 1)[1]
+    elif _arg in ("-t", "--tests") and _i < len(sys.argv) - 1:
+        OPT_TESTS = sys.argv[_i + 1]
+        _TESTS_EXPLICIT = True
+        _skip_next = True
+    elif _arg.startswith("--tests="):
+        OPT_TESTS = _arg.split("=", 1)[1]
+        _TESTS_EXPLICIT = True
+    elif _arg in ("-b", "--rdma-block-sizes") and _i < len(sys.argv) - 1:
+        OPT_RDMA_BLOCK_SIZES = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--rdma-block-sizes="):
+        OPT_RDMA_BLOCK_SIZES = _arg.split("=", 1)[1]
+    elif _arg in ("-s", "--rdma-latency-size") and _i < len(sys.argv) - 1:
+        OPT_RDMA_LATENCY_SIZE = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--rdma-latency-size="):
+        OPT_RDMA_LATENCY_SIZE = _arg.split("=", 1)[1]
+    elif _arg in ("-p", "--percentage-margin") and _i < len(sys.argv) - 1:
+        OPT_PERCENTAGE_MARGIN = float(sys.argv[_i + 1])
+        _skip_next = True
+    elif _arg.startswith("--percentage-margin="):
+        OPT_PERCENTAGE_MARGIN = float(_arg.split("=", 1)[1])
+    elif _arg in ("-i", "--install-deps"):
+        INSTALL_DEPS = True
+    elif _arg == "--ssh-command" and _i < len(sys.argv) - 1:
+        OPT_SSH_COMMAND = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--ssh-command="):
+        OPT_SSH_COMMAND = _arg.split("=", 1)[1]
+    elif _arg == "--ssh-hosts" and _i < len(sys.argv) - 1:
+        OPT_SSH_HOSTS = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--ssh-hosts="):
+        OPT_SSH_HOSTS = _arg.split("=", 1)[1]
+    elif _arg == "--nixlbench-backend" and _i < len(sys.argv) - 1:
+        OPT_NIXLBENCH_BACKEND = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--nixlbench-backend="):
+        OPT_NIXLBENCH_BACKEND = _arg.split("=", 1)[1]
+    elif _arg == "--nixlbench-seg-type" and _i < len(sys.argv) - 1:
+        OPT_NIXLBENCH_SEG_TYPE = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--nixlbench-seg-type="):
+        OPT_NIXLBENCH_SEG_TYPE = _arg.split("=", 1)[1]
+    elif _arg == "--nixlbench-buffer-size" and _i < len(sys.argv) - 1:
+        OPT_NIXLBENCH_BUFFER_SIZE = sys.argv[_i + 1]
+        _skip_next = True
+    elif _arg.startswith("--nixlbench-buffer-size="):
+        OPT_NIXLBENCH_BUFFER_SIZE = _arg.split("=", 1)[1]
+
+USE_DEBUG_CONTAINER = bool(DEBUG_IMAGE)
+DEBUG_SUFFIX = "-debug"
+
+# Resolve test list
+VALID_TESTS = {"perftest", "iperf3", "nccl-rccl", "nixlbench"}
+ALL_TESTS_ORDER = ["iperf3", "perftest", "nccl-rccl", "nixlbench"]  # default order for --tests all
+if OPT_TESTS.strip().lower() == "all":
+    SELECTED_TESTS = list(ALL_TESTS_ORDER)
+else:
+    SELECTED_TESTS = [t.strip().lower() for t in OPT_TESTS.split(",") if t.strip()]
+    unknown = set(SELECTED_TESTS) - VALID_TESTS
+    if unknown:
+        print(f"Error: unknown test(s): {', '.join(unknown)}.  Valid: {', '.join(sorted(VALID_TESTS))}, all", file=sys.stderr)
+        sys.exit(1)
+
+# Parse RDMA block sizes list (for bandwidth tests)
+RDMA_BLOCK_SIZES = [_common._parse_size(s) for s in OPT_RDMA_BLOCK_SIZES.split(",") if s.strip()]
+if not RDMA_BLOCK_SIZES:
+    print("Error: --rdma-block-sizes must contain at least one size.", file=sys.stderr)
+    sys.exit(1)
+
+# Parse RDMA latency message size
+RDMA_LATENCY_SIZE = _common._parse_size(OPT_RDMA_LATENCY_SIZE)
+
+# Perftest settings
+PERFTEST_DURATION = int(os.environ.get("PERFTEST_DURATION", "5"))
+PERFTEST_ITERATIONS = int(os.environ.get("PERFTEST_ITERATIONS", "1000"))
+PERFTEST_PORT = int(os.environ.get("PERFTEST_PORT", "18515"))
+
+# Parse SSH options
+import shlex as _shlex
+_SSH_COMMAND = None
+_SSH_HOSTS = []
+_ssh_target_map = {}
+if OPT_SSH_HOSTS:
+    _SSH_COMMAND = _shlex.split(OPT_SSH_COMMAND) if OPT_SSH_COMMAND else ["ssh"]
+    _SSH_HOSTS, _ssh_target_map = _common._parse_ssh_hosts(OPT_SSH_HOSTS)
+    if USE_DEBUG_CONTAINER:
+        print("Warning: --debug-image is ignored in SSH mode", file=sys.stderr)
+        USE_DEBUG_CONTAINER = False
+elif OPT_SSH_COMMAND:
+    print("Error: --ssh-command requires --ssh-hosts", file=sys.stderr)
+    sys.exit(1)
+
+# Push all parsed config into the common module so submodules can access it.
+_common.configure(
+    VERBOSE=VERBOSE,
+    DISCOVER_ONLY=DISCOVER_ONLY,
+    EXPLAIN=EXPLAIN,
+    EXPLAIN_VERIFY=EXPLAIN_VERIFY,
+    USE_DEBUG_CONTAINER=USE_DEBUG_CONTAINER,
+    DEBUG_IMAGE=DEBUG_IMAGE,
+    DEBUG_SUFFIX=DEBUG_SUFFIX,
+    INSTALL_DEPS=INSTALL_DEPS,
+    OPT_DEVICE=OPT_DEVICE,
+    OPT_GID_INDEX=OPT_GID_INDEX,
+    OPT_LABEL=OPT_LABEL,
+    OPT_NAMESPACE=OPT_NAMESPACE,
+    SSH_COMMAND=_SSH_COMMAND,
+    SSH_HOSTS=_SSH_HOSTS,
+    _ssh_target_map=_ssh_target_map,
+    DISPLAY_NAME_MAX_LEN=_common.DISPLAY_NAME_MAX_LEN,
+    PERFTEST_DURATION=PERFTEST_DURATION,
+    PERFTEST_ITERATIONS=PERFTEST_ITERATIONS,
+    PERFTEST_PORT=PERFTEST_PORT,
+    RDMA_BLOCK_SIZES=RDMA_BLOCK_SIZES,
+    RDMA_LATENCY_SIZE=RDMA_LATENCY_SIZE,
+    OPT_PERCENTAGE_MARGIN=OPT_PERCENTAGE_MARGIN,
+)
+
+
+# ===========================================================================
+# PERFTEST (in run-tests-perftest.py)
+# ===========================================================================
+_pf = _import_module("run-tests-perftest")
+run_perftest = _pf.run_perftest
+install_all_deps = _pf.install_all_deps
+build_perftest = _pf.build_perftest
+perftest_available = _pf.perftest_available
+_check_binaries = _pf._check_binaries
+PERFTEST_BINARIES = _pf.PERFTEST_BINARIES
+
+# ===========================================================================
+# IPERF3 (in run-tests-iperf3.py)
+# ===========================================================================
+_ip3 = _import_module("run-tests-iperf3")
+run_iperf3 = _ip3.run_iperf3
+
+# ===========================================================================
+# NCCL/RCCL (in run-tests-nccl-rccl.py)
+# ===========================================================================
+_nccl = _import_module("run-tests-nccl-rccl")
+run_nccl_rccl = _nccl.run_nccl_rccl
+
+# ===========================================================================
+# NIXLBENCH (in run-tests-nixlbench.py)
+# ===========================================================================
+_nlb = _import_module("run-tests-nixlbench")
+_nlb.NIXLBENCH_BACKEND = OPT_NIXLBENCH_BACKEND
+_nlb.NIXLBENCH_SEG_TYPE = OPT_NIXLBENCH_SEG_TYPE
+_nlb.NIXLBENCH_BUFFER_SIZE = OPT_NIXLBENCH_BUFFER_SIZE
+run_nixlbench = _nlb.run_nixlbench
+
+# ===========================================================================
+# GPU Topology Validation (in run-tests-discovery.py)
+# ===========================================================================
+_disc = _import_module("run-tests-discovery")
+run_topology_validation = _disc.run_topology_validation
+
+
+# ===========================================================================
+# Output: tables and heatmaps
+# ===========================================================================
+def _fmt_val(val, is_latency):
+    """Format a value with higher precision for latency metrics."""
+    if is_latency:
+        return f"{val:.4f}"
+    return f"{val:.2f}"
+
+
+def _is_latency_title(title):
+    t = title.lower()
+    return "latency" in t or "jitter" in t or "loss" in t
+
+
+def print_combined_table(pods, all_results, display_names):
+    """Print one combined table: rows = pod pairs, columns = test metrics."""
+    n = len(pods)
+    metrics = list(all_results.keys())
+    if not metrics:
+        return
+
+    # Build rows: one per directed pair (src -> dst)
+    pairs = []
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            src_short = display_names[pods[i][0]]
+            dst_short = display_names[pods[j][0]]
+            pairs.append((i, j, f"{src_short} -> {dst_short}"))
+
+    # Column widths
+    pair_width = max(len(p[2]) for p in pairs)
+    metric_widths = {}
+    for m in metrics:
+        is_lat = _is_latency_title(m)
+        # Width = max of header or formatted values
+        w = len(m)
+        for i, j, _ in pairs:
+            val = all_results[m][i][j]
+            if val is not None:
+                w = max(w, len(_fmt_val(val, is_lat)))
+            else:
+                w = max(w, 4)  # "FAIL"
+        metric_widths[m] = w
+
+    # Print header
+    print(f"\n{'=' * 60}")
+    print("  COMBINED RESULTS — All Tests")
+    print(f"{'=' * 60}")
+    header = " " * (pair_width + 2) + "  ".join(m.rjust(metric_widths[m]) for m in metrics)
+    print(header)
+    print("-" * len(header))
+
+    # Print rows
+    for i, j, pair_label in pairs:
+        cells = []
+        for m in metrics:
+            val = all_results[m][i][j]
+            w = metric_widths[m]
+            if val is not None:
+                cells.append(_fmt_val(val, _is_latency_title(m)).rjust(w))
+            else:
+                cells.append("FAIL".rjust(w))
+        print(f"{pair_label.rjust(pair_width)}  " + "  ".join(cells))
+
+    # Pod name legend
+    print(f"\nPod name legend:")
+    for name, _ip in pods:
+        print(f"  {display_names[name]:{_common.DISPLAY_NAME_MAX_LEN}s}  = {name}")
+    print()
+
+
+print_results_summary = _common.print_results_summary
+
+
+def generate_combined_png(pods, all_results, display_names, output="all.png"):
+    """Generate a single combined table as PNG: rows = pod pairs, columns = metrics."""
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        import numpy as np
+    except ImportError:
+        print("matplotlib not available — skipping PNG generation", file=sys.stderr)
+        return
+
+    n = len(pods)
+    metrics = list(all_results.keys())
+    if not metrics:
+        return
+
+    # Build pair labels and data grid
+    pair_labels = []
+    data_rows = []  # list of lists, one per pair
+    for i in range(n):
+        for j in range(n):
+            if i == j:
+                continue
+            src_short = display_names[pods[i][0]]
+            dst_short = display_names[pods[j][0]]
+            pair_labels.append(f"{src_short} -> {dst_short}")
+            row = []
+            for m in metrics:
+                row.append(all_results[m][i][j])
+            data_rows.append(row)
+
+    num_pairs = len(pair_labels)
+    num_metrics = len(metrics)
+
+    # Build cell text and colors
+    cell_text = []
+    cell_colors = []
+
+    for row in data_rows:
+        text_row = []
+        color_row = []
+        for col_idx, val in enumerate(row):
+            m = metrics[col_idx]
+            is_lat = _is_latency_title(m)
+            if val is not None:
+                text_row.append(_fmt_val(val, is_lat))
+                color_row.append("white")
+            else:
+                text_row.append("FAIL")
+                color_row.append("#ffcccc")
+        cell_text.append(text_row)
+        cell_colors.append(color_row)
+
+    # Color cells by relative value within each column
+    for col_idx, m in enumerate(metrics):
+        is_lat = _is_latency_title(m)
+        col_vals = [data_rows[r][col_idx] for r in range(num_pairs)
+                    if data_rows[r][col_idx] is not None]
+        if not col_vals:
+            continue
+        avg = np.mean(col_vals)
+        for r in range(num_pairs):
+            val = data_rows[r][col_idx]
+            if val is None:
+                continue
+            if is_lat:
+                # Higher than avg = worse for latency
+                if val > avg * 1.05:
+                    cell_colors[r][col_idx] = "#ffdddd"  # light red
+                elif val < avg * 0.95:
+                    cell_colors[r][col_idx] = "#ddffdd"  # light green
+            else:
+                # Lower than avg = worse for bandwidth
+                if val < avg * 0.9:
+                    cell_colors[r][col_idx] = "#ffdddd"
+                elif val > avg * 1.1:
+                    cell_colors[r][col_idx] = "#ddffdd"
+
+    # Figure sizing
+    col_w = max(1.8, max(len(m) for m in metrics) * 0.12)
+    row_h = 0.35
+    fig_w = max(10, 3 + num_metrics * col_w)
+    fig_h = max(6, 2 + num_pairs * row_h + 1.5)
+
+    fig, ax = plt.subplots(figsize=(fig_w, fig_h))
+    ax.axis("off")
+
+    table = ax.table(
+        cellText=cell_text,
+        rowLabels=pair_labels,
+        colLabels=metrics,
+        cellColours=cell_colors,
+        loc="center",
+        cellLoc="center",
+    )
+
+    table.auto_set_font_size(False)
+    table.set_fontsize(7)
+    table.scale(1, 1.3)
+
+    # Style header row
+    for col_idx in range(num_metrics):
+        cell = table[0, col_idx]
+        cell.set_facecolor("#4472C4")
+        cell.set_text_props(color="white", fontweight="bold", fontsize=6)
+
+    # Style row labels
+    for row_idx in range(num_pairs):
+        cell = table[row_idx + 1, -1]
+        cell.set_facecolor("#D9E2F3")
+        cell.set_text_props(fontsize=6)
+
+    # Pod name legend at bottom
+    legend_lines = [f"{display_names[p[0]]}  =  {p[0]}" for p in pods]
+    legend_text = "\n".join(legend_lines)
+    fig.text(
+        0.5, 0.01, legend_text,
+        ha="center", va="bottom", fontsize=6, family="monospace",
+        transform=fig.transFigure,
+        bbox=dict(boxstyle="round,pad=0.5", facecolor="lightyellow", edgecolor="gray", alpha=0.9),
+    )
+
+    plt.suptitle("Pod-to-Pod Network Tests — Combined Results", fontsize=12, fontweight="bold")
+    plt.tight_layout()
+    plt.savefig(output, dpi=150, bbox_inches="tight")
+    print(f"Combined results saved to {output}")
+
+
+# ===========================================================================
+# Main
+# ===========================================================================
+def main():
+    bw_sizes_str = ", ".join(_common._human_size(s) for s in RDMA_BLOCK_SIZES)
+    print(f"Selected tests: {', '.join(SELECTED_TESTS)}")
+    print(f"RDMA perftest BW message sizes: [{bw_sizes_str}]")
+    print(f"RDMA perftest latency message size: {_common._human_size(RDMA_LATENCY_SIZE)}")
+    print(f"iperf3: uses default buffer sizes (128K TCP, 8K UDP)")
+    if USE_DEBUG_CONTAINER:
+        print(f"Debug image: {DEBUG_IMAGE}")
+    else:
+        print("Running directly in pod containers (no debug image).")
+    print(f"Install deps if missing: {'yes' if INSTALL_DEPS else 'no (use --install-deps to enable)'}")
+
+    # Discover pods
+    print(f"\nDiscovering pods with label: {OPT_LABEL} ...")
+    pods = _common.discover_pods(OPT_LABEL)
+    display_names = _common.make_display_names([p[0] for p in pods])
+
+    # Detect pod roles (prefill / decode) for cross-role test filtering
+    _common.discover_pod_roles(OPT_LABEL)
+    role_info = []
+    for name, ip in pods:
+        role = _common.get_pod_role(name)
+        role_tag = f"  [{role}]" if role else ""
+        role_info.append((name, ip, role_tag))
+
+    print(f"Found {len(pods)} pod(s):")
+    for name, ip, role_tag in role_info:
+        print(f"  {display_names[name]:{_common.DISPLAY_NAME_MAX_LEN}s}  {name}  ({ip}){role_tag}")
+
+    # Show cross-role filtering status
+    test_pairs = _common._cross_role_pairs(pods)
+    all_pairs_count = len(pods) * (len(pods) - 1)
+    if len(test_pairs) < all_pairs_count:
+        prefill_count = sum(1 for n, _ in pods if _common.get_pod_role(n) == "prefill")
+        decode_count = sum(1 for n, _ in pods if _common.get_pod_role(n) == "decode")
+        print(f"  Cross-role testing: {prefill_count} prefill + {decode_count} decode pods "
+              f"→ {len(test_pairs)} cross-role pairs (skipping {all_pairs_count - len(test_pairs)} same-role pairs)")
+
+    # Create debug containers if any test needs them
+    if USE_DEBUG_CONTAINER:
+        print("\nCreating debug containers ...")
+        _common.create_debug_containers(pods)
+
+    # GPU topology validation — runs by default and with -d, skipped when -t is explicit
+    if DISCOVER_ONLY or not _TESTS_EXPLICIT:
+        run_topology_validation(pods, display_names)
+
+    if DISCOVER_ONLY:
+        print("Topology discovery complete (--discover-topology). Skipping network tests.")
+        return
+
+    # Map test -> (commands to check, human-readable label)
+    dep_map = {
+        "iperf3":    (["iperf3"],        "iperf3"),
+        "perftest":  (PERFTEST_BINARIES, "perftest"),
+        # nccl-rccl manages its own deps (mpirun, openssh, nccl/rccl-tests)
+        # inside run_nccl_rccl() — no upfront dep check needed.
+        # nixlbench manages its own deps (nixlbench binary + etcd)
+        # inside run_nixlbench() — no upfront dep check needed.
+    }
+
+    def check_deps():
+        """Check binaries for all selected tests. Returns set of tests with missing deps.
+
+        Uses a single kubectl exec per pod to check all required binaries at once.
+        """
+        # Collect all binaries needed across selected tests
+        all_binaries = []
+        for test in SELECTED_TESTS:
+            if test in dep_map:
+                all_binaries.extend(dep_map[test][0])
+        if not all_binaries:
+            return set()
+
+        # One exec per pod to check all binaries
+        pod_missing = {}  # pod_display_name -> set of missing binaries
+        for name, _ip in pods:
+            missing_bins = _check_binaries(name, all_binaries)
+            if missing_bins:
+                pod_missing[display_names[name]] = missing_bins
+
+        # Map results back to tests
+        tests_missing = set()
+        for test in SELECTED_TESTS:
+            if test not in dep_map:
+                continue
+            cmd_names, label = dep_map[test]
+            bad_pods = sorted(
+                pname for pname, mbins in pod_missing.items()
+                if mbins & set(cmd_names)
+            )
+            if bad_pods:
+                tests_missing.add(test)
+                print(f"  Warning: {label} not found on: {', '.join(bad_pods)}", file=sys.stderr)
+            else:
+                print(f"  {label}: OK on all pods")
+        return tests_missing
+
+    # First pass: check if all binaries are available
+    print("\nChecking dependencies on all pods ...")
+    tests_to_skip = check_deps()
+
+    # If any tests have missing deps and --install-deps is enabled, install and re-check
+    if tests_to_skip and INSTALL_DEPS:
+        print("\nMissing dependencies detected — installing on all pods in parallel ...")
+        need_perftest_build = "perftest" in tests_to_skip
+
+        n = len(pods)
+        buffers = [_common._StreamingBuffer() for _ in range(n)]
+        done_events = [threading.Event() for _ in range(n)]
+
+        def _install_worker(idx, pod_name, buf, done_evt):
+            try:
+                def _out(msg):
+                    buf.write(msg + "\n")
+
+                install_all_deps(pod_name, out=_out)
+                if need_perftest_build and not perftest_available(pod_name):
+                    build_perftest(pod_name, out=_out)
+            except Exception as exc:
+                buf.write(f"  ERROR installing on {pod_name}: {exc}\n")
+            finally:
+                done_evt.set()
+
+        # Launch all install threads
+        install_threads = []
+        for i, (name, _ip) in enumerate(pods):
+            t = threading.Thread(
+                target=_install_worker,
+                args=(i, name, buffers[i], done_events[i]),
+                daemon=True,
+            )
+            install_threads.append(t)
+            t.start()
+
+        # Stream output in pod order (first pod live, then second, etc.)
+        for i in range(n):
+            while not done_events[i].is_set():
+                buffers[i].flush_new()
+                done_events[i].wait(timeout=0.1)
+            buffers[i].flush_all()
+
+        for t in install_threads:
+            t.join(timeout=5)
+
+        # Re-check after installation
+        print("\nRe-checking dependencies after installation ...")
+        tests_to_skip = check_deps()
+
+    if tests_to_skip:
+        if not INSTALL_DEPS:
+            print(
+                f"\nHint: re-run with -i/--install-deps to automatically install "
+                f"missing dependencies.",
+                file=sys.stderr,
+            )
+        else:
+            print(
+                f"\nInstallation was attempted but some dependencies are still missing.\n"
+                f"The pod filesystem may be read-only or the package repo unavailable.",
+                file=sys.stderr,
+            )
+        remaining = [t for t in SELECTED_TESTS if t not in tests_to_skip]
+        if not remaining:
+            print(f"\nError: no tests can run — all selected tests have missing dependencies.", file=sys.stderr)
+            sys.exit(1)
+        print(f"\nSkipping tests with missing deps: {', '.join(sorted(tests_to_skip))}")
+        print(f"Will run: {', '.join(remaining)}")
+    else:
+        print("All dependencies OK.")
+
+    # Run tests in the order specified by --tests
+    test_runners = {
+        "iperf3":    run_iperf3,
+        "perftest":  run_perftest,
+        "nccl-rccl": run_nccl_rccl,
+        "nixlbench": run_nixlbench,
+    }
+    all_results = {}
+    for test in SELECTED_TESTS:
+        if test in tests_to_skip:
+            continue
+        results = test_runners[test](pods, display_names)
+        all_results.update(results)
+
+    # Separate matrix results (perftest, iperf3) from non-matrix results
+    # (nccl-rccl returns rows, not pod-pair matrices).
+    matrix_results = {k: v for k, v in all_results.items()
+                      if isinstance(v, list) and v and isinstance(v[0], list)}
+
+    # Print combined summary table, outlier analysis, and generate PNG
+    if matrix_results:
+        print_combined_table(pods, matrix_results, display_names)
+        print_results_summary(pods, matrix_results, display_names, OPT_PERCENTAGE_MARGIN)
+
+        run_all = set(SELECTED_TESTS) == VALID_TESTS or OPT_TESTS.strip().lower() == "all"
+        output_file = "all.png" if run_all else "tests-matrix.png"
+        generate_combined_png(pods, matrix_results, display_names, output=output_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Require uv
+if ! command -v uv &>/dev/null; then
+    echo "Error: uv is not installed. Install it from https://docs.astral.sh/uv/getting-started/installation/" >&2
+    exit 1
+fi
+
+uv run "$SCRIPT_DIR/run-tests.py" "$@"

--- a/skills/llm-d-networking-tests/SKILL.md
+++ b/skills/llm-d-networking-tests/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: llm-d-networking-tests
+description: Run networking tests for LLM-D to ensure the environment is properly set up before vLLM is started.
+---
+
+There are two steps to verify network performance of llm-d model deployment. First, after the model is deployed verify the topology of llm-d pods used by the model. For each pod if there are multiple GPUs allocated verify that they are optimally connected, in particular that they are as close as possible connected in PCIe with interconnects such as NVLink and NVSwitch for NVIDIA and Infinity Fabric and UALink for AMD. Second, for communication between pods verify that network fabric such Infiniband or RoCE is configured inside llm-d pods for expected latency and bandwidth.
+
+Use provided automation scripts run-test*.sh from https://github.com/llm-d/llm-d-pd-utils (if they are not availabel use https://github.com/aslom/llm-d-pd-utils).
+
+Ask user what namespace to use for tests (--namespace NS parameter in test scripts) and what pods label selector to use for testing (e.g. --label "llm-d.ai/role=decode" or "llm-d.ai/role=prefill"). The scripts will run tests in all pods matching the label selector.
+
+The tests can also be run using ssh instead of kubectl exec by providing --ssh and --host parameters to the test scripts. If using ssh, ensure that the test machine has network access to the nodes where llm-d pods are running and that SSH keys are properly configured.
+
+If additional information is needed use --verbose to print kubectl/SSH commands as they run. To make sure that the tests results can be reproduced by CLI commands use --explain-verify that extends the explain option to verify that each command when run as a CLI command produces expected output. The scripts will print out the exact kubectl or ssh commands used to run the tests for each pod. This allows users to easily rerun the tests manually if needed.
+
+Follow those steps to run the tests:
+
+- Confirm GPU topology inside pods:
+  - On NVIDIA nodes: use nvidia‑smi topo -m, lscpu, lspci -tv and nvidia‑smi nvlink --status to see whether GPUs are connected via NVLink/NVSwitch and not just PCIe. Check that there are minimal hops between GPUs (ideally NODE or NVLink instead of SYS or multiple PCIe hops) and If NVLink exists, GPUs in the pod are in the same NVLink group and not split across different NVSwitch domains
+  - On AMD: check GPU topology via rocm-smi and confirm that GPUs are connected via high‑bandwidth fabric (Infinity Fabric, UALink‑like topology) rather than only PCIe lanes.
+  - At this stage, an initial performance baseline can be defined for expected bandwidth and latency for both intra-pod and internal GPU-to-GPU communications.
+  - Run `./run-tests.sh --discovery` to automatically discover pods and run topology tests. This will print out the topology of each pod and whether it meets expected criteria for optimal GPU connectivity.
+  - In case that there are missing CLI tools inside the pods re-run with -i/--install-deps to automatically install missing dependencies: `./run-tests.sh --discovery --install-deps` that will nstall all test dependencies on every pod:
+  such as iperf3, perftest build tools, etcd, and nixlbench. It also builds perftest and nixlbench from source if missing and needed for testing.
+
+- Verify pods network configuration inisde pods and run network performance tests between pods:
+  - Check environment variables are used: such as NCCL_IB_HCA for the correct RDMA device (e.g., mlx5_0,mlx5_1), NCCL_IB_DISABLE=0 to enable InfiniBand/RoCE, NCCL_SOCKET_IFNAME for the RDMA‑capable interface (e.g., ib0, eth0), and NVSHMEM_USE_IB=1 to enable NVSHMEM over InfiniBand if using NVSHMEM. Also check that there are no conflicting variables such as NCCL_IB_DISABLE=1 or incorrect NCCL_IB_HCA values that would prevent RDMA from being used.
+  - Check that the expected RDMA interfaces (e.g., ib0) are present and properly configured inside the pods. Use `ip addr` to verify that the RDMA interfaces are up and have IP addresses assigned. Use `ibv_devinfo` to check that the InfiniBand devices are visible and properly configured inside the pods.
+  - Run network performance tests between pods:
+    - Use `iperf3` to measure TCP and RDMA bandwidth and latency between pods. Run `iperf3` in server mode on one pod and in client mode on another pod to measure the bandwidth and latency of the network fabric. Verify that the results meet expected performance baselines for the given hardware and network configuration.
+    - Use `perftest` (e.g., `ib_write_bw`, `ib_read_bw`, `ib_send_bw`) to measure RDMA bandwidth and latency between pods. This provides a more detailed view of RDMA performance compared to `iperf3`. Run `perftest` in server mode on one pod and in client mode on another pod to measure RDMA performance metrics. Verify that the results meet expected baselines for RDMA performance.
+    - If using NVSHMEM, use `nixlbench` to measure NVSHMEM performance between pods. Run `nixlbench` in server mode on one pod and in client mode on another pod to measure NVSHMEM bandwidth and latency. Verify that the results meet expected performance baselines for NVSHMEM over InfiniBand.
+    - If any of the tests fail to meet expected performance baselines, investigate potential issues with network configuration, pod placement, or hardware limitations. Check for any error messages in the test outputs and review the network configuration and topology to identify potential bottlenecks or misconfigurations. 
+    - Run `./run-tests.sh --tests all` or specify individual tests with `--tests perftest,iperf3,nccl-rccl,nixlbench` to run specific tests between pods. Use `--ssh` and `--host` parameters if running tests via SSH instead of kubectl exec. Choices: perftest, iperf3, nccl-rccl, nixlbench, all (default: perftest if not tests specified).  When -t isgiven explicitly, topology discovery is skipped (use -d to force it).
+
+The common problems leading to mismatch between performance test results and expected performance baseline are related to Kubernetes and topology GPUs on different PCIe roots / NUMA nodes. Each socket in a dual‑socket server owns its own PCIe root complex; if a pod gets GPUs on opposite sockets, their only path is via SYS‑style PCIe hops through the CPU interconnect. To see it use nvidia-smi topo -m shows SYS or PHB between GPUs in the pod, even though they’re on the same node and that leads to performance impact such as higher latency and cross‑socket PCIe contention, especially in collective operations.
+
+The other problem may happen when GPUs are spread across multiple PCIe root complexes as on larger nodes (e.g., 8 GPUs), some GPUs may be wired under different PCIe root ports or PCIe switches resulting that even if they are on the same NUMA node, GPUs may be separated by multiple PCIe bridges (PXB), sharing a bottlenecked upstream link.
+
+For step-by-step guide to troubleshoot GPU networking topology related to Kubernetes scheduling see [How PCIe, NVLink, and NUMA Topology Affect GPU Scheduling Outcomes](https://dev.to/daya-shankar/how-pcie-nvlink-and-numa-topology-affect-gpu-scheduling-outcomes-l52) and search web for common problems related to your hardware setup.

--- a/skills/llm-d-preflight-checks/SKILL.md
+++ b/skills/llm-d-preflight-checks/SKILL.md
@@ -21,6 +21,175 @@ When in `pause` mode, the HTTP server satisfies K8s health probes and provides:
 
 The script must be mounted into llm-d pods. To do this, create a ConfigMap with the script and mount it as a volume in the deployment. Then, modify the entrypoint of the container to run the preflight check script before starting vLLM.
 
+## Running preflight checks with llm-d quickstart
+
+Follow the [llm-d quickstart guide](https://llm-d.ai/docs/getting-started/quickstart) to deploy llm-d, then patch the model server deployment to run the preflight checks script before vLLM starts.
+
+### Prerequisites
+
+- llm-d deployed via the quickstart guide (Helm chart + model server kustomization)
+- A clone of `llm-d-pd-utils` containing the preflight checks script at `scripts/llm-d-preflight-checks.py` (or the skill directory at `.claude/skills/llm-d-preflight-checks/scripts/llm-d-preflight-checks.py`)
+
+### Step 1: Deploy llm-d via quickstart
+
+```bash
+cd /path/to/llm-d
+export GAIE_VERSION=v1.5.0
+export GUIDE_NAME="quickstart"
+export NAMESPACE=<your-namespace>
+
+# Install CRDs
+kubectl apply -k "https://github.com/kubernetes-sigs/gateway-api-inference-extension/config/crd?ref=${GAIE_VERSION}"
+kubectl create namespace ${NAMESPACE}
+
+# Deploy router
+helm install ${GUIDE_NAME} \
+    oci://registry.k8s.io/gateway-api-inference-extension/charts/standalone \
+    -f guides/recipes/scheduler/base.values.yaml \
+    -f guides/optimized-baseline/scheduler/optimized-baseline.values.yaml \
+    -n ${NAMESPACE} --version ${GAIE_VERSION}
+
+# Deploy model server
+kubectl apply -n ${NAMESPACE} -k guides/optimized-baseline/modelserver/gpu/vllm/base/
+```
+
+### Step 2: Create a ConfigMap with the preflight checks script
+
+```bash
+kubectl create configmap llm-d-preflight-checks \
+  --from-file=llm-d-preflight-checks.py=/path/to/llm-d-pd-utils/.claude/skills/llm-d-preflight-checks/scripts/llm-d-preflight-checks.py \
+  -n ${NAMESPACE}
+```
+
+### Step 3: Patch the model server deployment
+
+Apply a JSON patch to the deployment that:
+1. Adds a volume from the ConfigMap
+2. Mounts the script at `/preflight/llm-d-preflight-checks.py`
+3. Sets `LLMD_PREFLIGHT_CHECKS=pause` (or another mode)
+4. Changes the entrypoint to run the preflight script before vLLM via `&&`
+
+```bash
+kubectl patch deployment optimized-baseline-nvidia-gpu-vllm-decode \
+  -n ${NAMESPACE} --type=json -p '[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/volumes/-",
+    "value": {
+      "name": "preflight-checks",
+      "configMap": {
+        "name": "llm-d-preflight-checks",
+        "defaultMode": 493
+      }
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/volumeMounts/-",
+    "value": {
+      "name": "preflight-checks",
+      "mountPath": "/preflight"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/env",
+    "value": [
+      {
+        "name": "LLMD_PREFLIGHT_CHECKS",
+        "value": "pause"
+      }
+    ]
+  },
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/containers/0/command",
+    "value": ["bash", "-c"]
+  },
+  {
+    "op": "replace",
+    "path": "/spec/template/spec/containers/0/args",
+    "value": [
+      "python3 /preflight/llm-d-preflight-checks.py && vllm serve Qwen/Qwen3-32B --disable-access-log-for-endpoints=/health,/metrics,/v1/models --tensor-parallel-size=2 --gpu-memory-utilization=0.95"
+    ]
+  }
+]'
+```
+
+This triggers a rolling update. New pods will start the preflight script, which prints system diagnostics (environment variables, GPU topology via `nvidia-smi topo -m`, NVLink status, CPU info via `lscpu`) and then — in `pause` mode — starts an HTTP server on port 8000 that satisfies K8s health probes (`/health` returns 200) while blocking vLLM startup.
+
+The `&&` between the preflight script and `vllm serve` ensures vLLM only starts if the preflight script exits with code 0.
+
+### Step 4: Verify the preflight checks are running
+
+Wait for the rolling update to complete and check pod logs:
+
+```bash
+# Check pods are Running and Ready (preflight HTTP server satisfies probes)
+kubectl get pods -n ${NAMESPACE} -l llm-d.ai/model=Qwen3-32B
+
+# Verify the preflight script started
+kubectl logs -n ${NAMESPACE} <pod-name> | grep "llm-d-preflight-checks.py starting"
+
+# Verify pause mode is active
+kubectl logs -n ${NAMESPACE} <pod-name> | grep "LLMD_PREFLIGHT_CHECKS"
+
+# Test the preflight HTTP endpoints
+kubectl exec -n ${NAMESPACE} <pod-name> -- curl -s http://localhost:8000/health
+# Returns: {"status":"ok"}
+
+kubectl exec -n ${NAMESPACE} <pod-name> -- curl -s http://localhost:8000/info
+# Returns: full system diagnostics (env, GPU topology, NVLink, lscpu)
+```
+
+### Step 5: Resume vLLM startup
+
+When ready to let vLLM start (after inspecting diagnostics or running network tests), call `/exit` on each pod:
+
+```bash
+# Resume all pods matching the label
+for pod in $(kubectl get pods -n ${NAMESPACE} -l llm-d.ai/model=Qwen3-32B -o name); do
+  kubectl exec -n ${NAMESPACE} $pod -- curl -s http://localhost:8000/exit
+done
+```
+
+After `/exit` is called, the preflight server shuts down, the script exits with code 0, and `vllm serve` starts normally.
+
+### How it works
+
+The patch modifies the pod spec as follows:
+
+| Original | Patched |
+|----------|---------|
+| `command: ["vllm", "serve"]` | `command: ["bash", "-c"]` |
+| `args: ["Qwen/Qwen3-32B", ...]` | `args: ["python3 /preflight/llm-d-preflight-checks.py && vllm serve Qwen/Qwen3-32B ..."]` |
+| No ConfigMap volume | ConfigMap `llm-d-preflight-checks` mounted at `/preflight` (mode 0755) |
+| No env vars | `LLMD_PREFLIGHT_CHECKS=pause` |
+
+The ConfigMap volume (`defaultMode: 493` = octal `0755`) ensures the script is executable. The `bash -c` wrapper allows the `&&` chain to work: preflight runs first, and only if it exits 0 does vLLM start.
+
+In `pause` mode, the preflight HTTP server binds to port 8000 (the same port vLLM would use), so K8s startup/liveness/readiness probes pass while vLLM is not yet running. Once `/exit` is called, the server releases port 8000 and vLLM binds to it normally.
+
+### Changing preflight mode without redeployment
+
+To switch from `pause` to a non-blocking mode (e.g., diagnostics-only), patch just the env var:
+
+```bash
+kubectl set env deployment/optimized-baseline-nvidia-gpu-vllm-decode \
+  -n ${NAMESPACE} LLMD_PREFLIGHT_CHECKS=none
+```
+
+This triggers a new rollout where the preflight script prints diagnostics and exits immediately, allowing vLLM to start without manual intervention.
+
+### Cleanup
+
+To remove preflight checks entirely, redeploy the original model server kustomization:
+
+```bash
+kubectl apply -n ${NAMESPACE} -k /path/to/llm-d/guides/optimized-baseline/modelserver/gpu/vllm/base/
+kubectl delete configmap llm-d-preflight-checks -n ${NAMESPACE}
+```
+
 ## Running preflight checks with llm-d-benchmark
 
 The [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) framework can run the preflight checks script automatically before vLLM starts. The framework's step 04 (`04_ensure_model_namespace_prepared.py`) reads all files from `setup/preprocess/` into a ConfigMap named `llm-d-benchmark-preprocesses`, which gets mounted at `/setup/preprocess/` inside pods.

--- a/skills/llm-d-preflight-checks/SKILL.md
+++ b/skills/llm-d-preflight-checks/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: llm-d-preflight-checks
+description: Run preflight checks for LLM-D to ensure the environment is properly set up before vLLM is started.
+---
+
+Modify llm-d Helm deployment to run llm-d-preflight-checks/scripts/llm-d-preflight-checks.py just before starting vLLM. This script will perform various "preflight" checks to ensure that the environment is properly configured for LLM-D to run vLLM.
+
+The script behavior is controlled by the `LLMD_PREFLIGHT_CHECKS` environment variable:
+
+| Value | Behavior |
+|-------|----------|
+| unset / `disable` / `none` | Print system diagnostics (env, GPU, CPU, PCI) and exit 0 |
+| `pause` | Print diagnostics, then start HTTP server blocking until `/exit` is called |
+| `topology` | Print diagnostics and exit (reserved for future topology validation) |
+| `nixl` | Print diagnostics and exit (reserved for future NixL checks) |
+
+When in `pause` mode, the HTTP server satisfies K8s health probes and provides:
+- `GET /health` — 200 OK (for probes)
+- `GET /info` — system diagnostics
+- `GET /exit` — shut down server and continue to vLLM startup
+
+The script must be mounted into llm-d pods. To do this, create a ConfigMap with the script and mount it as a volume in the deployment. Then, modify the entrypoint of the container to run the preflight check script before starting vLLM.
+
+## Running preflight checks with llm-d-benchmark
+
+The [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) framework can run the preflight checks script automatically before vLLM starts. The framework's step 04 (`04_ensure_model_namespace_prepared.py`) reads all files from `setup/preprocess/` into a ConfigMap named `llm-d-benchmark-preprocesses`, which gets mounted at `/setup/preprocess/` inside pods.
+
+### Step 1: Symlink the script into llm-d-benchmark
+
+Create a symlink from the llm-d-benchmark `setup/preprocess/` directory to the preflight checks script:
+
+```bash
+ln -s /path/to/blog7/skills/llm-d-preflight-checks/scripts/llm-d-preflight-checks.py \
+      /path/to/llm-d-benchmark/setup/preprocess/llm-d-preflight-checks.py
+```
+
+This ensures the script is included in the `llm-d-benchmark-preprocesses` ConfigMap when step 04 runs.
+
+### Step 2: Update the scenario PREPROCESS variable
+
+In your scenario file (e.g., `scenarios/guides/pd-disaggregation2.sh`), set the `LLMDBENCH_VLLM_COMMON_PREPROCESS` variable to include the preflight checks script:
+
+```bash
+export LLMDBENCH_VLLM_COMMON_PREPROCESS="python3 /setup/preprocess/set_llmdbench_environment.py; source \$HOME/llmdbench_env.sh; python3 /setup/preprocess/llm-d-preflight-checks.py"
+```
+
+The script runs after `set_llmdbench_environment.py` and `source llmdbench_env.sh` so that environment variables like `VLLM_INFERENCE_PORT` are available.
+
+### Step 3: Set LLMD_PREFLIGHT_CHECKS in the scenario
+
+To control the preflight behavior, add `LLMD_PREFLIGHT_CHECKS` to the pod environment variables in the scenario's `LLMDBENCH_VLLM_COMMON_ENVVARS_TO_YAML` block. In `pd-disaggregation2.sh`, the env vars are defined like this:
+
+```bash
+export LLMDBENCH_VLLM_COMMON_ENVVARS_TO_YAML=$(mktemp)
+cat << EOF > $LLMDBENCH_VLLM_COMMON_ENVVARS_TO_YAML
+- name: NCCL_EXCLUDE_IB_HCA
+  value: "mlx5_0,mlx5_2,mlx5_4,mlx5_8,mlx5_7,mlx5_10,mlx5_12,mlx5_14,mlx5_16"
+- name: NVSHMEM_DEBUG
+  value: "INFO"
+- name: LLMD_PREFLIGHT_CHECKS
+  value: "pause"
+EOF
+```
+
+Add the `LLMD_PREFLIGHT_CHECKS` entry at the end of the YAML list. Valid values:
+
+| Value | Effect |
+|-------|--------|
+| `pause` | Print diagnostics, then block with HTTP server until `/exit` is called |
+| `disable` or `none` | Print diagnostics and exit immediately |
+| `topology` | Print diagnostics and exit (reserved for future topology checks) |
+| `nixl` | Print diagnostics and exit (reserved for future NixL checks) |
+
+If `LLMD_PREFLIGHT_CHECKS` is not set at all, the script defaults to printing diagnostics and exiting immediately (no blocking).
+
+When `pause` is set, pods will show as Ready (the preflight HTTP server responds to K8s health probes) but vLLM will **not** start until you explicitly call `/exit` on each pod:
+
+```bash
+# Resume a specific pod
+kubectl exec -n <namespace> <pod-name> -c vllm -- curl -s http://localhost:8000/exit
+
+# Resume all decode pods
+for pod in $(kubectl get pods -n <namespace> -l llm-d.ai/role=decode -o name); do
+  kubectl exec -n <namespace> $pod -c vllm -- curl -s http://localhost:8000/exit
+done
+
+# Resume all prefill pods
+for pod in $(kubectl get pods -n <namespace> -l llm-d.ai/role=prefill -o name); do
+  kubectl exec -n <namespace> $pod -c vllm -- curl -s http://localhost:8000/exit
+done
+```
+
+To disable pause mode and allow normal startup, either remove the `LLMD_PREFLIGHT_CHECKS` entry or change its value to `none`.
+
+### Step 4: Run the standup
+
+```bash
+source venv/bin/activate
+export LLMDBENCH_HF_TOKEN=<your-token>
+export LLMDBENCH_DEPLOY_MODEL_LIST="facebook/opt-125m"
+
+# Teardown any previous deployment
+./setup/teardown.sh -c ${PWD}/scenarios/guides/pd-disaggregation2.sh
+
+# Run standup steps 0-9
+./setup/standup.sh -v -c ${PWD}/scenarios/guides/pd-disaggregation2.sh -s 0-9
+```
+
+### How it works end-to-end
+
+1. **Step 04** reads all files in `setup/preprocess/` (including the symlinked `llm-d-preflight-checks.py`) and creates the `llm-d-benchmark-preprocesses` ConfigMap in the target namespace.
+
+2. **Scenario volume config** mounts the ConfigMap at `/setup/preprocess` inside pods:
+   ```yaml
+   volumes:
+   - name: preprocesses
+     configMap:
+       defaultMode: 0755
+       name: llm-d-benchmark-preprocesses
+   volumeMounts:
+   - name: preprocesses
+     mountPath: /setup/preprocess
+   ```
+
+3. **Pod startup command** is generated via `REPLACE_ENV_*` substitution in the pod spec. The scenario's `EXTRA_ARGS` template uses `&&` between the preflight script and vllm:
+   ```
+   python3 /setup/preprocess/set_llmdbench_environment.py; \
+   source $HOME/llmdbench_env.sh; \
+   python3 /setup/preprocess/llm-d-preflight-checks.py && \
+   vllm serve <model> --port $VLLM_INFERENCE_PORT ...
+   ```
+
+   The `&&` operator ensures that vllm only starts if the preflight checks script exits with code 0. If the script exits with a non-zero code (e.g., a future check detects a fatal misconfiguration), vllm will **not** start and the pod will fail — making the problem visible immediately rather than leading to hard-to-debug runtime errors.
+
+   This is configured in the scenario's `LLMDBENCH_VLLM_MODELSERVICE_PREFILL_EXTRA_ARGS` and `LLMDBENCH_VLLM_MODELSERVICE_DECODE_EXTRA_ARGS` templates:
+   ```bash
+   cat << EOF > $LLMDBENCH_VLLM_MODELSERVICE_PREFILL_EXTRA_ARGS
+   REPLACE_ENV_LLMDBENCH_VLLM_MODELSERVICE_PREFILL_PREPROCESS && \
+   vllm serve /model-cache/models/REPLACE_ENV_LLMDBENCH_DEPLOY_CURRENT_MODEL \
+   --host 0.0.0.0 \
+   ...
+   EOF
+   ```
+
+4. **Preflight script** checks `LLMD_PREFLIGHT_CHECKS` env var and either prints diagnostics and continues (default), or blocks with an HTTP server (`pause` mode) until `/exit` is called.
+
+### Verifying the preflight output
+
+After standup, check pod logs to see the preflight diagnostics:
+
+```bash
+kubectl logs -n <namespace> <pod-name> -c vllm | grep -A 50 "llm-d-preflight-checks.py starting"
+```

--- a/skills/llm-d-preflight-checks/scripts/llm-d-preflight-checks.py
+++ b/skills/llm-d-preflight-checks/scripts/llm-d-preflight-checks.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""
+LLM-D preflight checks for pod inspection before vLLM starts.
+
+Behavior is controlled by the LLMD_PREFLIGHT_CHECKS environment variable:
+    - unset, "disable", "none" — print diagnostics and exit immediately
+    - "pause" — start HTTP server that blocks until /exit is called
+    - "topology" — print diagnostics and exit (reserved for future topology checks)
+    - "nixl" — print diagnostics and exit (reserved for future NixL checks)
+
+When in "pause" mode, the HTTP server provides:
+    GET /health  — 200 OK (for K8s probes)
+    GET /info    — system diagnostics (env, GPU topology, CPU, PCI, etc.)
+    GET /exit    — gracefully shut down the server and continue startup
+    GET *        — 200 OK (catch-all for any other probe paths)
+
+Usage:
+    python3 llm-d-preflight-check.py [--info] [PORT]
+
+    --info  Print system diagnostics to stdout and exit (no server started).
+    PORT    defaults to 8000. If the port is in use, the next available port
+            (8001, 8002, ...) is tried automatically.
+"""
+
+import http.server
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import threading
+
+
+def run_cmd(cmd):
+    """Run a shell command and return its output, or an error message."""
+    try:
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, timeout=30
+        )
+        output = result.stdout.strip()
+        if result.returncode != 0 and result.stderr.strip():
+            output += "\n[stderr] " + result.stderr.strip()
+        return output if output else "(no output)"
+    except subprocess.TimeoutExpired:
+        return "(command timed out after 30s)"
+    except Exception as e:
+        return f"(error: {e})"
+
+
+def gather_info():
+    """Collect system diagnostics."""
+    sections = {}
+
+    # Environment variables (sorted)
+    sections["environment"] = "\n".join(
+        f"{k}={v}" for k, v in sorted(os.environ.items())
+    )
+
+    has_nvidia_smi = shutil.which("nvidia-smi") is not None
+    has_rocm_smi = shutil.which("rocm-smi") is not None
+
+    if has_nvidia_smi:
+        sections["nvidia-smi"] = run_cmd("nvidia-smi")
+        sections["nvidia-smi topo -m"] = run_cmd("nvidia-smi topo -m")
+        sections["nvidia-smi nvlink --status"] = run_cmd("nvidia-smi nvlink --status")
+    elif has_rocm_smi:
+        sections["rocm-smi"] = run_cmd("rocm-smi")
+        sections["rocm-smi --showtopo"] = run_cmd("rocm-smi --showtopo")
+        sections["rocm-smi --showbus"] = run_cmd("rocm-smi --showbus")
+    else:
+        sections["gpu"] = "(neither nvidia-smi nor rocm-smi found)"
+
+    if shutil.which("lscpu"):
+        sections["lscpu"] = run_cmd("lscpu")
+
+    if shutil.which("lspci"):
+        sections["lspci -tv"] = run_cmd("lspci -tv")
+
+    return sections
+
+
+def build_info_text(sections):
+    """Format diagnostics as plain text with section headers."""
+    parts = []
+    for title, content in sections.items():
+        parts.append(f"===== {title} =====")
+        parts.append(content)
+        parts.append("")
+    return "\n".join(parts)
+
+
+def find_available_port(start_port, max_attempts=100):
+    """Find an available port starting from start_port."""
+    for offset in range(max_attempts):
+        port = start_port + offset
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", port))
+                return port
+            except OSError:
+                if offset == 0:
+                    print(f"Port {port} is in use, trying next...")
+                continue
+    raise RuntimeError(
+        f"No available port found in range {start_port}-{start_port + max_attempts - 1}"
+    )
+
+
+def make_handler(shutdown_event):
+    """Create an HTTP request handler with /info and /exit endpoints."""
+
+    # Cache info output so repeated /info calls are fast
+    info_cache = {}
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/exit":
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"status":"shutting down"}\n')
+                shutdown_event.set()
+
+            elif self.path == "/info":
+                if "text" not in info_cache:
+                    sections = gather_info()
+                    info_cache["text"] = build_info_text(sections)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/plain; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(info_cache["text"].encode("utf-8", errors="replace"))
+
+            else:
+                # Catch-all: /health, /, or any other path — 200 OK for probes
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.end_headers()
+                self.wfile.write(b'{"status":"ok"}\n')
+
+        def log_message(self, format, *args):
+            # Suppress default access logs
+            pass
+
+    return Handler
+
+
+def run_server(start_port):
+    """Start the HTTP server and block until /exit is called."""
+    port = find_available_port(start_port)
+
+    shutdown_event = threading.Event()
+    handler_class = make_handler(shutdown_event)
+
+    server = http.server.HTTPServer(("", port), handler_class)
+    server.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    print(f"=== PAUSED: vLLM startup is on hold ===")
+    print(f"Preflight server listening on :{port}")
+    print(f"  GET /health — probe endpoint")
+    print(f"  GET /info   — system diagnostics (env, GPU, CPU, PCI)")
+    print(f"  GET /exit   — shut down server and continue startup")
+    print(f"To resume vLLM startup, call /exit:")
+    print(f"  curl http://localhost:{port}/exit")
+    print(f"Or from within the cluster:")
+    print(f"  kubectl exec <pod> -c vllm -- curl -s http://localhost:{port}/exit")
+
+    shutdown_event.wait()
+
+    print("Shutting down preflight server...")
+    server.shutdown()
+    print("Continuing...")
+
+
+def main():
+    print("=== llm-d-preflight-checks.py starting ===")
+
+    # Parse arguments: [--info] [PORT]
+    args = sys.argv[1:]
+    info_mode = False
+    if "--info" in args:
+        info_mode = True
+        args.remove("--info")
+
+    if args:
+        start_port = int(args[0])
+    else:
+        start_port = int(os.environ.get("VLLM_INFERENCE_PORT", "8000"))
+
+    # --info: print diagnostics to stdout and exit
+    if info_mode:
+        sections = gather_info()
+        print(build_info_text(sections))
+        return
+
+    raw_mode = os.environ.get("LLMD_PREFLIGHT_CHECKS", "")
+    mode = raw_mode.lower().strip()
+    if raw_mode:
+        print(f"LLMD_PREFLIGHT_CHECKS={raw_mode!r} (mode={mode!r})")
+    else:
+        print("LLMD_PREFLIGHT_CHECKS is not set, defaulting to diagnostics-only mode")
+
+    if mode == "pause":
+        sections = gather_info()
+        print(build_info_text(sections))
+        print("=== Preflight checks PAUSED: waiting for /exit before allowing regular pod startup ===")
+        run_server(start_port)
+    elif mode in ("topology", "nixl"):
+        print(f"Mode {mode!r}: printing diagnostics (extended checks not yet implemented)")
+        sections = gather_info()
+        print(build_info_text(sections))
+    else:
+        # unset, "disable", "none", or any unrecognized value
+        sections = gather_info()
+        print(build_info_text(sections))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
No automated way existed to validate RDMA, NVLink, and network health across
Kubernetes inference pods before serving traffic. This PR adds a modular test
suite that discovers pods, validates GPU topology, and runs perftest, iperf3,
NCCL/RCCL, and NIXLBench between all pairs — plus a preflight-checks skill
for pre-vLLM environment validation.

**Files to review (10, +8344 / -0):**

| File | Why |
|---|---|
| `run-tests.py` *(start here)* | Unified CLI entry point — parses options, dispatches to test modules. |
| `run-tests-common.py` | Shared config, kubectl helpers, pod discovery, explain/verify logic. |
| `run-tests-discovery.py` | GPU topology validation: nvidia-smi topo, NVLink, NUMA, PCIe, env vars. |
| `run-tests-perftest.py` | RDMA perftest runner (ib_{read,write,send}_{lat,bw}), auto-detects device/GID. |
| `run-tests-iperf3.py` | iperf3 TCP bandwidth + UDP jitter/loss between pod pairs. |
| `run-tests-nccl-rccl.py` | NCCL/RCCL all_reduce_perf across same-vendor GPU pods via mpirun. |
| `run-tests-nixlbench.py` | NIXLBench RDMA/GPU memory transfer benchmark with etcd coordination. |
| `run-tests.sh` | Shell wrapper — validates `uv` is installed, delegates to `run-tests.py`. |
| `skills/llm-d-preflight-checks/SKILL.md` | Claude Code skill: preflight checks for llm-d pods before vLLM starts. |
| `skills/.../llm-d-preflight-checks.py` | Preflight script: diagnostics, pause mode with HTTP server, env validation. |

## Why

LLM inference with disaggregated prefill/decode requires validated RDMA
connectivity, correct GPU topology (NVLink/NVSwitch), and proper environment
variables (NCCL, UCX, NIXL) across all pods. Without automated validation,
misconfigurations silently degrade throughput or cause hangs at scale.

## How

1. `run-tests.sh` ensures `uv` is present and delegates to `run-tests.py`.
2. `run-tests.py` parses CLI flags and dispatches to per-test modules.
3. All modules share `run-tests-common.py` for kubectl exec, pod discovery,
   explain/verify, and server lifecycle management.
4. Discovery runs first (unless `-t` is explicit), then selected tests run
   pairwise across all discovered pods.
5. Results flag outliers exceeding `--percentage-margin` from the mean.

Supports both NVIDIA and AMD GPUs, direct pod exec or ephemeral debug
containers, optional SSH mode for bare-metal, and `--install-deps` to
build tools from source inside pods.

## Notes for reviewer

- **Modules use importlib, not regular imports.** Python module names contain
  hyphens (`run-tests-common`), so standard `import` syntax doesn't work.
  Lazy `_get_common()` avoids circular imports during module loading.
- **`--explain` and `--explain-verify` are for auditing.** They print the
  exact kubectl commands used for each finding, enabling manual reproduction.
  `--explain-verify` re-runs each command and compares output.
- **Preflight skill is separate from test suite.** The skill runs *inside*
  inference pods before vLLM starts (via ConfigMap mount). The test suite
  runs *externally* against running pods.

## Tests

Manual testing against Kubernetes clusters with NVIDIA/AMD GPU nodes.
No automated test suite yet — tests require real hardware and RDMA-capable
pods.

## Follow-up

- Add NIXL tests and optimize tests for quick execution.
- Add matrix plot output (`--plot`) for visual bandwidth comparisons.

Signed-off-by: Aleksander Slominski <aslom@us.ibm.com>

