### PR TITLE
fix: correct typo installion -> installing

### DIFF
--- a/installers/install_nixl.sh
+++ b/installers/install_nixl.sh
@@ -45,7 +45,7 @@ if [ ! -e "/dev/gdrdrv" ] || [ "$FORCE" = true ]; then
     
     cd ..
 else
-    echo "Found /dev/gdrdrv. Skipping gdrcopy installion"
+    echo "Found /dev/gdrdrv. Skipping gdrcopy installing"
 fi
 
 if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
@@ -89,7 +89,7 @@ if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
 
     cd ..
 else
-    echo "Found existing UCX. Skipping UCX installion"  
+    echo "Found existing UCX. Skipping UCX installing"  
 fi
 
 if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
@@ -104,5 +104,5 @@ if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
 
     cd ../..
 else
-    echo "Found existing NIXL. Skipping NIXL installion"  
+    echo "Found existing NIXL. Skipping NIXL installing"  
 fi


### PR DESCRIPTION
## Summary
Fix 3 typos in `installers/install_nixl.sh`: 'installion' → 'installing' at lines 48, 92, and 107.

## Changes
- Line 48: `Skipping gdrcopy installion` → `Skipping gdrcopy installing`
- Line 92: `Skipping UCX installion` → `Skipping UCX installing`
- Line 107: `Skipping NIXL installion` → `Skipping NIXL installing`

## Test Plan
- Verified the typo exists in upstream main
- Applied fix and pushed to fork
- Typos fixed: 3 replacements

Closes llm-d/llm-d-pd-utils#29