### PR TITLE
docs: fix preflight namespace typo

### DIFF
--- a/docs/preflight-checks-design.md
+++ b/docs/preflight-checks-design.md
@@ -36,7 +36,7 @@ Apart from preflight checks, to automate testing, we also provide scripts and an
 
 
 ```
-follow https://llm-d.ai/docs/getting-started/quickstart to install llm-d in llm-d-quickstart namspace and run /llm-d-preflight-checks in that namespace to use preflight checks script in installed pods. if necessary add or modify or locally load helm chars to add preflight checks script and env variable LLMD_PREFLIGHT_CHECKS with "pause"
+follow https://llm-d.ai/docs/getting-started/quickstart to install llm-d in llm-d-quickstart namespace and run /llm-d-preflight-checks in that namespace to use preflight checks script in installed pods. if necessary add or modify or locally load helm chars to add preflight checks script and env variable LLMD_PREFLIGHT_CHECKS with "pause"
 ```
 
 ```


### PR DESCRIPTION
## Problem
Issue #29 reports typo-checker findings, including `namspace` in `docs/preflight-checks-design.md`.

## Solution
Correct `llm-d-quickstart namspace` to `llm-d-quickstart namespace`.

Note: I left the `first_pn` occurrences unchanged because they are a local variable abbreviation for pod name rather than prose typos.

## Validation
- `git diff --check`
- `git grep -n 'namspace'` returns no matches

Confidence: 85/100 (docs/typo)

Closes #29