### PR TITLE
Fix typo: installion -> installing in install_nixl.sh (llm-d/llm-d-pd-utils#29)

### DIFF
--- a/installers/install_nixl.sh
+++ b/installers/install_nixl.sh
@@ -45,7 +45,7 @@ if [ ! -e "/dev/gdrdrv" ] || [ "$FORCE" = true ]; then
     
     cd ..
 else
-    echo "Found /dev/gdrdrv. Skipping gdrcopy installion"
+    echo "Found /dev/gdrdrv. Skipping gdrcopy installing"
 fi
 
 if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
@@ -89,7 +89,7 @@ if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
 
     cd ..
 else
-    echo "Found existing UCX. Skipping UCX installion"  
+    echo "Found existing UCX. Skipping UCX installing"  
 fi
 
 if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
@@ -104,5 +104,5 @@ if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
 
     cd ../..
 else
-    echo "Found existing NIXL. Skipping NIXL installion"  
+    echo "Found existing NIXL. Skipping NIXL installing"  
 fi


### PR DESCRIPTION
Fixes llm-d/llm-d-pd-utils#29 — corrects three instances of \installion\ to \installing\ in \installers/install_nixl.sh\ (lines 48, 92, 107). Found by nightly typo scan.