### PR TITLE
fix: correct 'installion' to 'installation' in install_nixl.sh

### DIFF
--- a/installers/install_nixl.sh
+++ b/installers/install_nixl.sh
@@ -45,7 +45,7 @@ if [ ! -e "/dev/gdrdrv" ] || [ "$FORCE" = true ]; then
     
     cd ..
 else
-    echo "Found /dev/gdrdrv. Skipping gdrcopy installion"
+    echo "Found /dev/gdrdrv. Skipping gdrcopy installation"
 fi
 
 if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
@@ -89,7 +89,7 @@ if ! command -v ucx_info &> /dev/null || [ "$FORCE" = true ]; then
 
     cd ..
 else
-    echo "Found existing UCX. Skipping UCX installion"  
+    echo "Found existing UCX. Skipping UCX installation"  
 fi
 
 if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
@@ -104,5 +104,5 @@ if ! command -v nixl_test &> /dev/null || [ "$FORCE" = true ]; then
 
     cd ../..
 else
-    echo "Found existing NIXL. Skipping NIXL installion"  
+    echo "Found existing NIXL. Skipping NIXL installation"  
 fi


### PR DESCRIPTION
## Summary
Fixes 3 instances of typo `installion` → `installation` in `installers/install_nixl.sh`:

- Line 48: `Skipping gdrcopy installion` → `Skipping gdrcopy installation`
- Line 92: `Skipping UCX installion` → `Skipping UCX installation`  
- Line 107: `Skipping NIXL installion` → `Skipping NIXL installation`

## Testing
- ✅ Single commit, no unrelated changes
- ✅ Follows existing echo message style
- ✅ No code logic changed, only string fix

Fixes #29